### PR TITLE
Changes to implement a lowP  multi helix trigger

### DIFF
--- a/core/filters/trigAprFilters.fcl
+++ b/core/filters/trigAprFilters.fcl
@@ -9,6 +9,8 @@ TrigAprFilters:{
       eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
   aprHighPStopTargMultiTrkPS: { module_type: PrescaleEvent
       eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
+   aprLowPMultiHelixPS: { module_type: PrescaleEvent
+      eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
 
   aprHighPStopTargHSFilter: {
     module_type: "HelixFilter"

--- a/core/filters/trigAprFilters.fcl
+++ b/core/filters/trigAprFilters.fcl
@@ -405,15 +405,13 @@ TrigAprFilters:{
     timeClusterCollection: "TTTZClusterFinder"
   }
   aprLowPMultiHelixKSFilter: {
-    kalSeedCollection: "TTAprKSF"
+    kalSeedCollection: ["TTAprKSF"]
     module_type: "KalSeedFilter"
     minNTrks: 2
     KalSeedCuts : [
       { #cuts for downstreeam e-minus
-        doParticleTypeCheck: false
-        doZPropDirCheck: true
-        fitdirection: 0
-        fitparticle: 11
+        fitdirection: @local::FitDir.downstream
+        fitparticle: @local::Particle.eminus
         maxChi2DOF: 20
         maxD0: 600
         maxMomErr: 10
@@ -423,15 +421,12 @@ TrigAprFilters:{
         minFitCons: -1
         minMomentum: 50
         minNStrawHits: 12
-        minT0: 0
         minTanDip: 0
         requireCaloCluster: false
       },
       { #cuts for downstreeam e-plus
-        doParticleTypeCheck: false
-        doZPropDirCheck: true
-        fitdirection: 0
-        fitparticle: -11
+        fitdirection: @local::FitDir.downstream
+        fitparticle: @local::Particle.eplus
         maxChi2DOF: 20
         maxD0: 600
         maxMomErr: 10
@@ -441,7 +436,6 @@ TrigAprFilters:{
         minFitCons: -1
         minMomentum: 50
         minNStrawHits: 12
-        minT0: 0
         minTanDip: 0
         requireCaloCluster: false
       }

--- a/core/filters/trigAprFilters.fcl
+++ b/core/filters/trigAprFilters.fcl
@@ -7,7 +7,7 @@ TrigAprFilters:{
       eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
   aprHighPPS               : { module_type: PrescaleEvent
       eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
-  aprLowPStopTargMultiTrkPS: { module_type: PrescaleEvent
+  aprHighPStopTargMultiTrkPS: { module_type: PrescaleEvent
       eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
 
   aprHighPStopTargHSFilter: {
@@ -266,7 +266,7 @@ TrigAprFilters:{
     ]
   }
 
-  aprLowPStopTargMultiTrkHSFilter: {
+  aprHighPStopTargMultiTrkHSFilter: {
     helixSeedCollection: "TTAprHelixMerger"
     module_type: "HelixFilter"
     minNHelices: 2
@@ -309,13 +309,13 @@ TrigAprFilters:{
       requireCaloCluster: false
     }
   }
-  aprLowPStopTargMultiTrkTCFilter: {
+  aprHighPStopTargMultiTrkTCFilter: {
     minNStrawHits: 10
     module_type: "TimeClusterFilter"
     requireCaloCluster: false
     timeClusterCollection: "TTTZClusterFinder"
   }
-  aprLowPStopTargMultiTrkKSFilter: {
+  aprHighPStopTargMultiTrkKSFilter: {
     kalSeedCollections: [ "TTAprKSF" ]
     module_type: "KalSeedFilter"
     minNTrks: 2
@@ -352,6 +352,100 @@ TrigAprFilters:{
       }
     ]
   }
+
+  aprLowPMultiHelixHSFilter: {
+    helixSeedCollection: "TTAprHelixMerger"
+    module_type: "HelixFilter"
+    minNHelices: 2
+    posHelicitySelection : {
+      configured: true
+      doHelicityCheck: true
+      maxAbsLambda: 500
+      maxChi2PhiZ: 8
+      maxChi2XY: 8
+      maxD0: 600
+      maxMomentum: 2000
+      maxNLoops: 30
+      minAbsLambda: 50
+      minD0: -600
+      minHitRatio: 4e-1
+      minMomentum: 50
+      minNLoops: 0
+      minNStrawHits: 15
+      minPt: 0
+      prescaleUsingD0Phi: false
+      requireCaloCluster: false
+    }
+    negHelicitySelection : {
+      configured: true
+      doHelicityCheck: true
+      maxAbsLambda: 500
+      maxChi2PhiZ: 8
+      maxChi2XY: 8
+      maxD0: 600
+      maxMomentum: 2000
+      maxNLoops: 30
+      minAbsLambda: 50
+      minD0: -600
+      minHitRatio: 4e-1
+      minMomentum: 50
+      minNLoops: 0
+      minNStrawHits: 15
+      minPt: 0
+      prescaleUsingD0Phi: false
+      requireCaloCluster: false
+    }
+  }
+  aprLowPMultiHelixTCFilter: {
+    minNStrawHits: 10
+    module_type: "TimeClusterFilter"
+    requireCaloCluster: false
+    timeClusterCollection: "TTTZClusterFinder"
+  }
+  aprLowPMultiHelixKSFilter: {
+    kalSeedCollection: "TTAprKSF"
+    module_type: "KalSeedFilter"
+    minNTrks: 2
+    KalSeedCuts : [
+      { #cuts for downstreeam e-minus
+        doParticleTypeCheck: false
+        doZPropDirCheck: true
+        fitdirection: 0
+        fitparticle: 11
+        maxChi2DOF: 20
+        maxD0: 600
+        maxMomErr: 10
+        maxMomentum: 2000
+        maxTanDip: 100
+        minD0: -600
+        minFitCons: -1
+        minMomentum: 50
+        minNStrawHits: 12
+        minT0: 0
+        minTanDip: 0
+        requireCaloCluster: false
+      },
+      { #cuts for downstreeam e-plus
+        doParticleTypeCheck: false
+        doZPropDirCheck: true
+        fitdirection: 0
+        fitparticle: -11
+        maxChi2DOF: 20
+        maxD0: 600
+        maxMomErr: 10
+        maxMomentum:2000
+        maxTanDip: 100
+        minD0: -600
+        minFitCons: -1
+        minMomentum: 50
+        minNStrawHits: 12
+        minT0: 0
+        minTanDip: 0
+        requireCaloCluster: false
+      }
+    ]
+  }
+
 
   #aprHelix filters
   aprHelixHSFilter: {

--- a/core/producers/trigAprProducers.fcl
+++ b/core/producers/trigAprProducers.fcl
@@ -56,7 +56,7 @@ TrigAprProducers : {
   aprHighPStopTargMultiTrkTriggerInfoMerger: {
     module_type: "MergeTriggerInfo"
   }
-  aprLowPStopTargMultiHelixTriggerInfoMerger: {
+  aprLowPMultiHelixTriggerInfoMerger: {
     module_type: "MergeTriggerInfo"
   }
   aprHelixTriggerInfoMerger: {

--- a/core/producers/trigAprProducers.fcl
+++ b/core/producers/trigAprProducers.fcl
@@ -53,7 +53,10 @@ TrigAprProducers : {
   aprLowPStopTargTriggerInfoMerger: {
     module_type: "MergeTriggerInfo"
   }
-  aprLowPStopTargMultiTrkTriggerInfoMerger: {
+  aprHighPStopTargMultiTrkTriggerInfoMerger: {
+    module_type: "MergeTriggerInfo"
+  }
+  aprLowPStopTargMultiHelixTriggerInfoMerger: {
     module_type: "MergeTriggerInfo"
   }
   aprHelixTriggerInfoMerger: {

--- a/core/trigSequences.fcl
+++ b/core/trigSequences.fcl
@@ -185,7 +185,7 @@ TrigTrkPaths:{
       aprLowPStopTargHSFilter, TTAprKSF, aprLowPStopTargKSFilter, aprLowPStopTargTriggerInfoMerger ]
 
    apr_highP_stopTarg_multiTrk       : [ @sequence::TrigRecoSequences.dtcAndCFOEventsGen,
-      aprLowPStopTargMultiTrkPS, @sequence::TrigRecoSequences.calReco,
+      aprHighPStopTargMultiTrkPS, @sequence::TrigRecoSequences.calReco,
       @sequence::TrigRecoSequences.trkPrepareHits,
       TTTZClusterFinder, aprHighPStopTargMultiTrkTCFilter, TTAprHelixFinder, TTAprHelixMerger,
       aprHighPStopTargMultiTrkHSFilter, TTAprKSF, aprHighPStopTargMultiTrkKSFilter, aprHighPStopTargMultiTrkTriggerInfoMerger ]

--- a/core/trigSequences.fcl
+++ b/core/trigSequences.fcl
@@ -184,11 +184,17 @@ TrigTrkPaths:{
       TTTZClusterFinder, aprLowPStopTargTCFilter, TTAprHelixFinder, TTAprHelixMerger,
       aprLowPStopTargHSFilter, TTAprKSF, aprLowPStopTargKSFilter, aprLowPStopTargTriggerInfoMerger ]
 
-   apr_lowP_stopTarg_multiTrk       : [ @sequence::TrigRecoSequences.dtcAndCFOEventsGen,
+   apr_highP_stopTarg_multiTrk       : [ @sequence::TrigRecoSequences.dtcAndCFOEventsGen,
       aprLowPStopTargMultiTrkPS, @sequence::TrigRecoSequences.calReco,
       @sequence::TrigRecoSequences.trkPrepareHits,
-      TTTZClusterFinder, aprLowPStopTargMultiTrkTCFilter, TTAprHelixFinder, TTAprHelixMerger,
-      aprLowPStopTargMultiTrkHSFilter, TTAprKSF, aprLowPStopTargMultiTrkKSFilter, aprLowPStopTargMultiTrkTriggerInfoMerger ]
+      TTTZClusterFinder, aprHighPStopTargMultiTrkTCFilter, TTAprHelixFinder, TTAprHelixMerger,
+      aprHighPStopTargMultiTrkHSFilter, TTAprKSF, aprHighPStopTargMultiTrkKSFilter, aprHighPStopTargMultiTrkTriggerInfoMerger ]
+
+   apr_lowP_multiHelix       : [ @sequence::TrigRecoSequences.artFragmentsGen,
+      aprLowPMultiHelixPS, @sequence::TrigRecoSequences.calReco,
+      @sequence::TrigRecoSequences.trkPrepareHits,
+      TTTZClusterFinder, aprLowPMultiHelixTCFilter, TTAprHelixFinder, TTAprHelixMerger,
+      aprLowPMultiHelixHSFilter, TTAprKSF, aprLowPMultiHelixKSFilter, aprLowPMultiHelixTriggerInfoMerger ]
 
    apr_lowP_stopTarg_timing0       : [ @sequence::TrigRecoSequences.dtcAndCFOEventsGen,
       aprLowPStopTargPS, @sequence::TrigRecoSequences.calReco,

--- a/data/physMenu.json
+++ b/data/physMenu.json
@@ -126,8 +126,16 @@
                                ]
         },
 
-         "apr_lowP_stopTarg_multiTrk"   : {
+         "apr_highP_stopTarg_multiTrk"   : {
             "bit" : 191 ,
+            "enabled": 1,
+            "eventModeConfig": [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ] },
+                                {"eventMode":"OffSpill", "prescale":1, "streams": [ "cosmics_main", "physics_trk_calib" ]          }
+                               ]
+         },
+
+	 "apr_lowP_multiHelix"   : {
+            "bit" : 192 ,
             "enabled": 1,
             "eventModeConfig": [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ] },
                                 {"eventMode":"OffSpill", "prescale":1, "streams": [ "cosmics_main", "physics_trk_calib" ]          }

--- a/data/valMenu.json
+++ b/data/valMenu.json
@@ -104,8 +104,16 @@
                                ]
         },
 
-         "apr_lowP_stopTarg_multiTrk"   : {
+         "apr_highP_stopTarg_multiTrk"   : {
             "bit" : 191 ,
+            "enabled": 1,
+            "eventModeConfig": [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ] },
+                                {"eventMode":"OffSpill", "prescale":1, "streams": [ "cosmics_main", "physics_trk_calib" ]          }
+                               ]
+         },
+
+	"apr_lowP_multiHelix"   : {
+            "bit" : 192 ,
             "enabled": 1,
             "eventModeConfig": [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ] },
                                 {"eventMode":"OffSpill", "prescale":1, "streams": [ "cosmics_main", "physics_trk_calib" ]          }


### PR DESCRIPTION
I added a new trigger path for multi helix at lowP. In addition, I changed the name of apr_LowP_StopTarg to apr_HighP_StopTarg as its minimum momentum requirement was 80 MeV. 

Tagging: @gianipez @matthewstortini @michaelmackenzie 