### PR TITLE
now the gneerateMenuFromJSON script can be run from anywhere

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,3 +34,4 @@ install_fhicl(SUBDIRS core/filters   SUBDIRNAME mu2e-trig-config/core/filters)
 install(DIRECTORY data DESTINATION ${CMAKE_INSTALL_DATAROOTDIR})
 install(DIRECTORY python DESTINATION .)
 
+cet_script(python/generateMenuFromJSON.py)

--- a/python/generateMenuFromJSON.py
+++ b/python/generateMenuFromJSON.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import json
 import os
 


### PR DESCRIPTION
This PR partially addresses issue #54 . Now the python script can be run from anywhere. I tested it. 
tagging @corrodis 
