### PR TITLE
Update reference log file, add ability to use CI check with the old github repo name

### DIFF
--- a/ci/check_trigger_results.sh
+++ b/ci/check_trigger_results.sh
@@ -1,12 +1,18 @@
 #! /bin/bash
 # Compare a local trigger log to a reference log file
 
+# Check the trigger directory name for the old style
+TRIGDIR="mu2e-trig-config/"
+if [ ! -d ${TRIGDIR} ]; then
+    TRIGDIR="mu2e_trig_config/"
+fi
+
 # Process the example data-like digi file
 NEVENTS=-1
-DATAFILE="mu2e-trig-config/ci/data_files.txt"
+DATAFILE="${TRIGDIR}ci/data_files.txt"
 LOGFILE="local_trigger_results.log"
-REFERENCE="mu2e-trig-config/ci/reference_log_file.log"
-mu2e -c mu2e-trig-config/test/triggerTest.fcl -S ${DATAFILE} -n ${NEVENTS} >| ${LOGFILE}
+REFERENCE="${TRIGDIR}ci/reference_log_file.log"
+mu2e -c ${TRIGDIR}test/triggerTest.fcl -S ${DATAFILE} -n ${NEVENTS} >| ${LOGFILE}
 STATUS=$?
 
 # Add the log to the stdout report
@@ -19,6 +25,6 @@ if [ $STATUS -ne 0 ]; then
 fi
 
 # Compare the log file to an example log file
-python mu2e-trig-config/ci/check_trigger_results.py ${LOGFILE} ${REFERENCE}
+python ${TRIGDIR}ci/check_trigger_results.py ${LOGFILE} ${REFERENCE}
 STATUS=$?
 exit $STATUS

--- a/ci/reference_log_file.log
+++ b/ci/reference_log_file.log
@@ -1,7 +1,7 @@
    ************************** Mu2e Offline **************************
      art v3_14_03    root v6_30_04    KinKal v03_01_05
      build  /exp/mu2e/app/users/mmackenz/Yale/main
-     build  al9-prof-e28-p068    02/17/25 09:38:27
+     build  al9-prof-e28-p068    03/09/25 22:24:52
    ******************************************************************
 Conditions file: /exp/mu2e/app/users/mmackenz/Yale/main/Offline/ConditionsService/data/conditions_01.txt
 Conditions lines: 38  hash: 8098310628555253397
@@ -14,16 +14,16 @@ BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing (
 BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing ( 0x1 : Inactive )
 BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing ( 0x1 : Inactive )
 DeltaFinderAlg created
-17-Feb-2025 10:20:10 CST  Initiating request to open input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
-17-Feb-2025 10:20:11 CST  Opened input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
+10-Mar-2025 08:32:35 CDT  Initiating request to open input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
+10-Mar-2025 08:32:36 CDT  Opened input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
 tprHelixDeIpaHSFilter NO HELIX CUT HAS BEEN SET FOR THE HELICES WITH NEGATIVE HELICITY. IF THAT'S NOT THE DESIRED BEHAVIOUR REVIEW YOUR CONFIGUREATION!
 tprHelixDeIpaPhiScaledHSFilter NO HELIX CUT HAS BEEN SET FOR THE HELICES WITH NEGATIVE HELICITY. IF THAT'S NOT THE DESIRED BEHAVIOUR REVIEW YOUR CONFIGUREATION!
 Geometry file: /exp/mu2e/app/users/mmackenz/Yale/main/Offline/Mu2eG4/geom/geom_common.txt
-Geometry lines: 21588  hash: 17682376866590487674
+Geometry lines: 22069  hash: 9704073641230452930
 BField file: /exp/mu2e/app/users/mmackenz/Yale/main/Offline/Mu2eG4/geom/bfgeom_reco_v01.txt
 BField lines: 98  hash: 3243269116804334601
-Begin processing the 1st record. run: 1202 subRun: 0 event: 1 at 17-Feb-2025 10:20:38 CST
-DbReader::fillValCache took 232.113 s
+Begin processing the 1st record. run: 1202 subRun: 0 event: 1 at 10-Mar-2025 08:33:19 CDT
+DbReader::fillValCache took 0.23503 s
 DbEngine confirmed purpose and version:
 MDC2020_best 1/3/-1
 DbEngine IoV summary
@@ -48,168 +48,167 @@ DbEngine IoV summary
              CRVSiPM       3
            CRVPhoton       3
              CRVTime       3
-DbEngine inclusive beginJob time was 232.193 s
-Begin processing the 2nd record. run: 1202 subRun: 0 event: 2 at 17-Feb-2025 10:24:31 CST
-Begin processing the 3rd record. run: 1202 subRun: 0 event: 3 at 17-Feb-2025 10:24:31 CST
-Begin processing the 5th record. run: 1202 subRun: 0 event: 5 at 17-Feb-2025 10:24:31 CST
-Begin processing the 9th record. run: 1202 subRun: 0 event: 9 at 17-Feb-2025 10:24:31 CST
-Begin processing the 17th record. run: 1202 subRun: 0 event: 17 at 17-Feb-2025 10:24:31 CST
-Begin processing the 33rd record. run: 1202 subRun: 0 event: 33 at 17-Feb-2025 10:24:31 CST
-Begin processing the 65th record. run: 1202 subRun: 0 event: 65 at 17-Feb-2025 10:24:32 CST
-Begin processing the 129th record. run: 1202 subRun: 0 event: 129 at 17-Feb-2025 10:24:32 CST
-Begin processing the 257th record. run: 1202 subRun: 0 event: 257 at 17-Feb-2025 10:24:34 CST
-Begin processing the 513th record. run: 1202 subRun: 0 event: 513 at 17-Feb-2025 10:24:39 CST
-Begin processing the 1025th record. run: 1202 subRun: 0 event: 1025 at 17-Feb-2025 10:24:48 CST
-Begin processing the 2049th record. run: 1202 subRun: 0 event: 2049 at 17-Feb-2025 10:25:04 CST
-Begin processing the 4097th record. run: 1202 subRun: 1 event: 97 at 17-Feb-2025 10:25:37 CST
-Begin processing the 8193rd record. run: 1202 subRun: 2 event: 193 at 17-Feb-2025 10:26:48 CST
-17-Feb-2025 10:27:19 CST  Closed input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
-17-Feb-2025 10:27:19 CST  Initiating request to open input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
-17-Feb-2025 10:27:19 CST  Opened input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
-%MSG-w GEOM:  BeginRun 17-Feb-2025 10:27:19 CST run: 1202
+DbEngine inclusive beginJob time was 0.235244 s
+Begin processing the 2nd record. run: 1202 subRun: 0 event: 2 at 10-Mar-2025 08:33:19 CDT
+Begin processing the 3rd record. run: 1202 subRun: 0 event: 3 at 10-Mar-2025 08:33:19 CDT
+Begin processing the 5th record. run: 1202 subRun: 0 event: 5 at 10-Mar-2025 08:33:19 CDT
+Begin processing the 9th record. run: 1202 subRun: 0 event: 9 at 10-Mar-2025 08:33:20 CDT
+Begin processing the 17th record. run: 1202 subRun: 0 event: 17 at 10-Mar-2025 08:33:20 CDT
+Begin processing the 33rd record. run: 1202 subRun: 0 event: 33 at 10-Mar-2025 08:33:20 CDT
+Begin processing the 65th record. run: 1202 subRun: 0 event: 65 at 10-Mar-2025 08:33:21 CDT
+Begin processing the 129th record. run: 1202 subRun: 0 event: 129 at 10-Mar-2025 08:33:21 CDT
+Begin processing the 257th record. run: 1202 subRun: 0 event: 257 at 10-Mar-2025 08:33:23 CDT
+Begin processing the 513th record. run: 1202 subRun: 0 event: 513 at 10-Mar-2025 08:33:28 CDT
+Begin processing the 1025th record. run: 1202 subRun: 0 event: 1025 at 10-Mar-2025 08:33:36 CDT
+Begin processing the 2049th record. run: 1202 subRun: 0 event: 2049 at 10-Mar-2025 08:33:53 CDT
+Begin processing the 4097th record. run: 1202 subRun: 1 event: 97 at 10-Mar-2025 08:34:25 CDT
+Begin processing the 8193rd record. run: 1202 subRun: 2 event: 193 at 10-Mar-2025 08:35:35 CDT
+10-Mar-2025 08:36:04 CDT  Closed input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
+10-Mar-2025 08:36:04 CDT  Initiating request to open input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
+10-Mar-2025 08:36:04 CDT  Opened input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
+%MSG-w GEOM:  BeginRun 10-Mar-2025 08:36:04 CDT run: 1202
 This test version does not change geometry on run boundaries.
 %MSG
 This test version does not change geometry on run boundaries.
-Begin processing the 16385th record. run: 1202 subRun: 4 event: 385 at 17-Feb-2025 10:29:05 CST
-17-Feb-2025 10:30:06 CST  Closed input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
+Begin processing the 16385th record. run: 1202 subRun: 4 event: 385 at 10-Mar-2025 08:37:51 CDT
+10-Mar-2025 08:38:51 CDT  Closed input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
 
 =======================================================================================================================================================================
 TimeTracker printout (sec)                                                               Min           Avg           Max         Median          RMS         nEvts   
 =======================================================================================================================================================================
-Full event                                                                           0.000942301    0.0282682      232.79      0.00899329      1.64605       20000   
+Full event                                                                           0.000945036    0.0165087     0.851346     0.00889814     0.0222335      20000   
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-source:RootInput(read)                                                               6.4232e-05    0.000163611    0.131794     0.000104881   0.00150758      20000   
-caloHitRec_N0Source:artFragFromDTCEvents:ArtFragmentsFromDTCEvents                    1.068e-05    1.50279e-05   0.000219089    1.308e-05    5.27123e-06     20000   
-caloHitRec_N0Source:caloHitRecN0SourcePS:PrescaleEvent                                8.737e-06    1.48946e-05   0.00216858    1.1573e-05    3.79091e-05     20000   
-minBias_CDCount:minBiasCDCountPS:PrescaleEvent                                        1.803e-06    2.70304e-06   0.000164835    2.365e-06    2.11113e-06     20000   
-minBias_SDCount:minBiasSDCountPS:PrescaleEvent                                        1.442e-06    2.15989e-06   0.000209902    1.963e-06    1.91506e-06     20000   
-cstCosmicTrackSeed:cstCosmicTrackSeedPS:PrescaleEvent                                 1.492e-06    2.20118e-06   0.000199361    1.893e-06    2.78126e-06     20000   
-cstTimeCluster:cstTimeClusterPS:PrescaleEvent                                         1.452e-06    2.24811e-06   0.000169454    1.864e-06    1.77716e-06     20000   
-caloFast_RMC:caloFastRMCPS:PrescaleEvent                                              1.443e-06    1.99612e-06   0.000101905    1.803e-06    1.31922e-06     20000   
-caloFast_RMC:CaloHitMakerFast:CaloHitMakerFast                                       7.4333e-05    0.000590829    0.0165322    0.00046029    0.000489035     20000   
-caloFast_RMC:CaloClusterFast:CaloClusterFast                                          9.448e-06    6.31782e-05   0.000515466   5.31015e-05   3.92281e-05     20000   
-caloFast_RMC:caloFastRMCFilter:CaloClusterCounterFilter                               6.503e-06    9.1804e-06    0.000160497    8.277e-06    3.41766e-06     20000   
-caloFast_cosmic:caloFastCosmicPS:PrescaleEvent                                        2.274e-06    3.63298e-06   0.000197648    3.317e-06    2.67936e-06     20000   
-caloFast_cosmic:caloFastCosmicFilter:CaloCosmicCalib                                  4.45e-06     6.16588e-06   7.3551e-05     5.43e-06     2.47932e-06     20000   
-caloFast_MVANNCE:caloFastMVANNCEPS:PrescaleEvent                                      1.653e-06    2.52308e-06   0.000193731    2.134e-06    2.43633e-06     20000   
-caloFast_MVANNCE:caloFastMVANNCEFilter:FilterEcalNNTrigger                            5.059e-06    8.78267e-06   0.000193029    7.705e-06    4.39115e-06     20000   
-caloFast_photon:caloFastPhotonPS:PrescaleEvent                                        1.603e-06    2.22107e-06   4.7571e-05     1.963e-06    1.26136e-06     20000   
-caloFast_photon:caloFastPhotonFilter:CaloLikelihood                                   5.09e-06     8.7381e-06    0.000888378    6.503e-06    8.55208e-06     20000   
-aprHelix:aprLowPStopTargPS:PrescaleEvent                                              1.623e-06    2.44305e-06   5.1888e-05     2.174e-06    1.30271e-06     20000   
-aprHelix:TTmakeSH:StrawHitReco                                                       3.5939e-05     0.0120958      232.781     0.000385582     1.64597       20000   
-aprHelix:TTmakePH:CombineStrawHits                                                    8.758e-06    6.28867e-05   0.000613282   5.00005e-05   4.57135e-05     20000   
-aprHelix:TTflagPH:DeltaFinder                                                        8.4822e-05    0.000425196   0.00435432    0.000333297   0.000317906     20000   
-aprHelix:TTTZClusterFinder:TZClusterFinder                                           1.2024e-05    6.68199e-05   0.00178436    5.0402e-05    5.39912e-05     20000   
-aprHelix:aprHelixTCFilter:TimeClusterFilter                                           9.458e-06    1.37285e-05   0.000219659   1.2364e-05    4.90074e-06     20000   
-aprHelix:TTAprHelixFinder:AgnosticHelixFinder                                         1.085e-05    0.000414099    0.0161174    0.000140168   0.000753267     15995   
-aprHelix:TTAprHelixMerger:MergeHelices                                               1.1191e-05    1.55004e-05   0.00038706    1.3886e-05    6.97616e-06     15995   
-aprHelix:aprHelixHSFilter:HelixFilter                                                 5.751e-06    8.35098e-06   0.000204771    7.505e-06    3.60854e-06     15995   
-apr_lowP_stopTarg_multiTrk:aprLowPStopTargMultiTrkPS:PrescaleEvent                    2.184e-06    3.71576e-06   0.00127337     3.306e-06    9.22422e-06     20000   
-apr_lowP_stopTarg_multiTrk:aprLowPStopTargMultiTrkTCFilter:TimeClusterFilter          7.304e-06    1.09164e-05   0.000448747   1.0009e-05    4.78517e-06     20000   
-apr_lowP_stopTarg_multiTrk:aprLowPStopTargMultiTrkHSFilter:HelixFilter                5.34e-06     7.26263e-06    0.0002985     6.473e-06    3.80432e-06     15995   
-apr_lowP_stopTarg:aprLowPStopTargTCFilter:TimeClusterFilter                           6.262e-06    8.61551e-06   9.0342e-05     7.724e-06    3.10385e-06     20000   
-apr_lowP_stopTarg:aprLowPStopTargHSFilter:HelixFilter                                 4.779e-06    6.57926e-06   0.000175515    5.802e-06    2.92384e-06     15995   
-apr_highP:aprHighPPS:PrescaleEvent                                                    1.663e-06    2.49199e-06    0.0001157     2.204e-06    1.47039e-06     20000   
-apr_highP:aprHighPTCFilter:TimeClusterFilter                                          6.192e-06    8.44871e-06   0.000190784    7.454e-06    3.81563e-06     20000   
-apr_highP:aprHighPHSFilter:HelixFilter                                                4.659e-06    6.30601e-06   0.000297878    5.552e-06    3.83744e-06     15995   
-apr_highP_stopTarg:aprHighPStopTargPS:PrescaleEvent                                   1.603e-06    2.37961e-06   8.2569e-05     2.094e-06    1.32447e-06     20000   
-apr_highP_stopTarg:aprHighPStopTargTCFilter:TimeClusterFilter                         6.172e-06    8.37241e-06   0.000213789    7.454e-06    3.62579e-06     20000   
-apr_highP_stopTarg:aprHighPStopTargHSFilter:HelixFilter                               4.669e-06    6.1755e-06    0.000169664    5.461e-06    2.69162e-06     15995   
-cprHelixUe:cprHelixUePS:PrescaleEvent                                                 1.653e-06    2.43134e-06   0.000181798    2.135e-06    2.00733e-06     20000   
-cprHelixUe:TTCalTimePeakFinderUe:CalTimePeakFinder                                    7.985e-06    1.28755e-05   0.000138915   1.0129e-05    7.35295e-06     20000   
-cprHelixUe:cprHelixUeTCFilter:TimeClusterFilter                                       7.324e-06    9.48726e-06   0.00021539     8.526e-06    4.05129e-06     20000   
-cprHelixDe:cprHelixDePS:PrescaleEvent                                                 1.573e-06    2.58938e-06   6.3541e-05     2.285e-06    1.45513e-06     20000   
-cprHelixDe:TTCalTimePeakFinder:CalTimePeakFinder                                      6.663e-06    1.02963e-05   0.000199362    7.825e-06    6.75622e-06     20000   
-cprHelixDe:cprHelixDeTCFilter:TimeClusterFilter                                       6.662e-06    8.74068e-06   0.000163823    7.784e-06    3.39794e-06     20000   
-cprDe_lowP_stopTarg:cprDeLowPStopTargPS:PrescaleEvent                                 1.703e-06    2.62759e-06   0.000191295    2.254e-06    2.28292e-06     20000   
-cprDe_lowP_stopTarg:cprDeLowPStopTargTCFilter:TimeClusterFilter                       6.412e-06    8.47255e-06   6.4473e-05     7.514e-06    2.84926e-06     20000   
-cprDe_highP:cprDeHighPPS:PrescaleEvent                                                1.583e-06    2.18493e-06    3.601e-05     1.934e-06    1.08514e-06     20000   
-cprDe_highP:cprDeHighPTCFilter:TimeClusterFilter                                      6.091e-06    7.91919e-06   0.000228115    7.013e-06    3.28483e-06     20000   
-cprDe_highP_stopTarg:cprDeHighPStopTargPS:PrescaleEvent                               1.553e-06    2.20084e-06   4.6127e-05     1.894e-06    1.18748e-06     20000   
-cprDe_highP_stopTarg:cprDeHighPStopTargTCFilter:TimeClusterFilter                     5.881e-06    7.81369e-06   0.000198569    6.933e-06    3.15231e-06     20000   
-tprHelixUe:tprHelixUePS:PrescaleEvent                                                 1.693e-06    2.44209e-06   0.000195283    2.114e-06    1.86955e-06     20000   
-tprHelixUe:TTtimeClusterFinderUe:TimeClusterFinder                                   2.9517e-05    0.00149266     0.0229885    0.000890471   0.00186924      20000   
-tprHelixUe:tprHelixUeTCFilter:TimeClusterFilter                                       7.704e-06    1.37704e-05   0.00116153    1.2554e-05    1.01145e-05     20000   
-tprHelixUe:TThelixFinderUe:RobustHelixFinder                                          9.658e-06    0.000307172    0.0206636    0.000129372   0.000559542     19786   
-tprHelixUe:TTHelixMergerUe:MergeHelices                                              1.0229e-05    1.7037e-05    0.000262452   1.4578e-05    8.14154e-06     19786   
-tprHelixUe:tprHelixUeHSFilter:HelixFilter                                             5.72e-06     9.1913e-06    0.000206074    7.865e-06    3.95514e-06     19786   
-tprHelixDe:tprHelixDePS:PrescaleEvent                                                 1.773e-06    3.19905e-06   0.000191246    2.936e-06    1.9735e-06      20000   
-tprHelixDe:TTtimeClusterFinder:TimeClusterFinder                                      2.613e-05    0.00141041     0.0218508    0.000829215   0.00181063      20000   
-tprHelixDe:tprHelixDeTCFilter:TimeClusterFilter                                       6.793e-06    1.35349e-05   0.000849343   1.2594e-05    7.59736e-06     20000   
-tprHelixDe:TThelixFinder:RobustHelixFinder                                            7.684e-06    0.000327508    0.0138789    0.000135689   0.000585914     19813   
-tprHelixDe:TTHelixMergerDe:MergeHelices                                               9.247e-06    1.63699e-05   0.000262462   1.4048e-05    7.78394e-06     19813   
-tprHelixDe:tprHelixDeHSFilter:HelixFilter                                             5.049e-06    8.70031e-06   0.00075851     7.394e-06    6.81277e-06     19813   
-tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledPS:PrescaleEvent                       1.814e-06    3.28882e-06   0.000139597    3.036e-06    1.70272e-06     20000   
-tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTCFilter:TimeClusterFilter             6.403e-06    1.11213e-05   0.000200213    1.027e-05    4.44503e-06     20000   
-tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledHSFilter:HelixFilter                    4.7e-06     6.72468e-06   5.3382e-05     5.851e-06    2.49109e-06     19813   
-tprHelixDe_ipa:tprHelixDeIpaPS:PrescaleEvent                                          1.644e-06    2.51787e-06   0.000103779    2.254e-06    1.44957e-06     20000   
-tprHelixDe_ipa:tprHelixDeIpaTCFilter:TimeClusterFilter                                6.092e-06    8.95867e-06   0.000246491   8.0255e-06    4.01552e-06     20000   
-tprHelixDe_ipa:tprHelixDeIpaHSFilter:HelixFilter                                      4.428e-06    6.25074e-06   5.3221e-05     5.46e-06     2.43836e-06     19813   
-tprDe_lowP_stopTarg:tprDeLowPStopTargPS:PrescaleEvent                                 1.653e-06    2.46294e-06   0.000223638    2.124e-06    2.80286e-06     20000   
-tprDe_lowP_stopTarg:tprDeLowPStopTargTCFilter:TimeClusterFilter                       6.562e-06    9.08099e-06   0.000347314    8.096e-06    5.24754e-06     20000   
-tprDe_lowP_stopTarg:tprDeLowPStopTargHSFilter:HelixFilter                             4.87e-06     7.11643e-06   0.000180023    6.372e-06    2.88057e-06     19904   
-tprDe_highP:tprDeHighPPS:PrescaleEvent                                                1.633e-06    2.44374e-06   3.9376e-05     2.063e-06    1.25576e-06     20000   
-tprDe_highP:tprDeHighPTCFilter:TimeClusterFilter                                      6.522e-06    9.11847e-06   0.000187709    7.945e-06    3.46537e-06     20000   
-tprDe_highP:tprDeHighPHSFilter:HelixFilter                                            4.698e-06    7.04319e-06   0.000386849    5.871e-06    4.1839e-06      19813   
-tprDe_highP_stopTarg:tprDeHighPStopTargPS:PrescaleEvent                               1.593e-06    2.34164e-06   0.000187038    2.054e-06    1.81748e-06     20000   
-tprDe_highP_stopTarg:tprDeHighPStopTargTCFilter:TimeClusterFilter                     6.322e-06    8.66333e-06   0.000299252    7.675e-06    5.05791e-06     20000   
-tprDe_highP_stopTarg:tprDeHighPStopTargHSFilter:HelixFilter                           4.508e-06    6.62968e-06   0.000173613    5.691e-06    3.21399e-06     19813   
-mprDe_highP_stopTarg:mprDeHighPStopTargPS:PrescaleEvent                               1.593e-06    2.2183e-06    0.000190474    1.954e-06    2.04555e-06     20000   
-mprDe_highP_stopTarg:mprDeHighPStopTargTCFilter:TimeClusterFilter                     6.442e-06    9.9017e-06    0.000431413    7.945e-06    1.50906e-05     20000   
-mprDe_highP_stopTarg:TTRobustMultiHelixFinder:RobustMultiHelixFinder                 1.6772e-05     0.0033225     0.177859     0.00110781    0.00751062      19813   
-mprDe_highP_stopTarg:TTMprHelixMergerDe:MergeHelices                                 1.2514e-05    0.000169897   0.00550745     4.657e-05    0.000365067     19813   
-mprDe_highP_stopTarg:mprDeHighPStopTargHSFilter:HelixFilter                           5.261e-06    2.21512e-05   0.00203311    1.7444e-05    2.17624e-05     19813   
-mprDe_highP_stopTarg:TTMprKSFDe:LoopHelixFit                                         0.000126321    0.0102355     0.0773878    0.00725604    0.00951125      12188   
-mprDe_highP_stopTarg:mprDeHighPStopTargKSFilter:KalSeedFilter                         7.734e-06    1.90162e-05   0.000230451   1.6446e-05    9.61077e-06     12188   
-[art]:TriggerResults:TriggerResultInserter                                            3.587e-06    5.24572e-06   0.00032992     4.429e-06    3.4462e-06      20000   
-cprHelixUe:TTCalHelixFinderUe:CalHelixFinder                                         5.2931e-05    0.00022089    0.00273785    0.00015654    0.000190053     1456    
-cprHelixUe:TTCalHelixMergerUe:MergeHelices                                           1.0691e-05    1.48197e-05   5.0457e-05    1.35655e-05   3.78438e-06     1456    
-cprHelixUe:cprHelixUeHSFilter:HelixFilter                                             6.101e-06    8.68335e-06   2.5779e-05     7.905e-06    2.3877e-06      1456    
-cprHelixDe:TTCalHelixFinderDe:CalHelixFinder                                         4.4475e-05    0.000220955   0.00241188    0.000155747   0.000201632     1579    
-cprHelixDe:TTCalHelixMergerDe:MergeHelices                                            1.03e-05     1.46514e-05   0.000191195   1.3155e-05    6.35929e-06     1579    
-cprHelixDe:cprHelixDeHSFilter:HelixFilter                                             5.81e-06     9.06345e-06   3.6791e-05     7.975e-06    3.22273e-06     1579    
-cprDe_lowP_stopTarg:cprDeLowPStopTargHSFilter:HelixFilter                             5.27e-06     8.47309e-06   3.9776e-05     7.675e-06    2.87116e-06     1579    
-cprDe_highP:cprDeHighPHSFilter:HelixFilter                                            4.959e-06    7.27484e-06   3.5988e-05     6.403e-06    2.75214e-06     1579    
-cprDe_highP_stopTarg:cprDeHighPStopTargHSFilter:HelixFilter                           5.09e-06     7.54027e-06   4.0427e-05     6.843e-06    2.46087e-06     1579    
-tprHelixDe:tprHelixDeTriggerInfoMerger:MergeTriggerInfo                              1.3226e-05    2.11215e-05   0.000223658   1.8296e-05    9.01345e-06     1413    
-tprDe_lowP_stopTarg:TTKSFDe:LoopHelixFit                                             0.000156429   0.00177551     0.0116476     0.0014906    0.00121455      1729    
-tprDe_lowP_stopTarg:tprDeLowPStopTargKSFilter:KalSeedFilter                           7.415e-06    1.40098e-05   0.000191015   1.2874e-05    6.26899e-06     1729    
-tprDe_lowP_stopTarg:tprDeLowPStopTargTriggerInfoMerger:MergeTriggerInfo              1.5831e-05    1.96083e-05   3.7261e-05    1.79295e-05   4.11151e-06      166    
-aprHelix:aprHelixTriggerInfoMerger:MergeTriggerInfo                                  1.4768e-05    2.40734e-05   6.3853e-05     2.362e-05    7.02644e-06      306    
-apr_highP:TTAprKSF:LoopHelixFit                                                      0.000171799   0.000728128   0.00267638    0.000558873   0.000548707      92     
-apr_highP:aprHighPKSFilter:KalSeedFilter                                              4.748e-06    8.35229e-06   2.2753e-05    6.8485e-06    3.69196e-06      234    
-tprHelixUe:tprHelixUeTriggerInfoMerger:MergeTriggerInfo                              1.3936e-05    2.43506e-05   0.00021974    2.3826e-05    8.53827e-06     1884    
-tprDe_highP:tprDeHighPKSFilter:KalSeedFilter                                          4.689e-06    7.95822e-06   0.000205122    7.154e-06    6.89093e-06     1089    
-tprDe_highP_stopTarg:tprDeHighPStopTargKSFilter:KalSeedFilter                         4.549e-06    6.98665e-06   0.000157952    6.412e-06    6.21282e-06      695    
-tprHelixDe_ipa:tprHelixDeIpaTriggerInfoMerger:MergeTriggerInfo                        9.999e-06    1.52528e-05   4.0467e-05    1.4018e-05    4.78385e-06      543    
-tprDe_lowP_stopTarg:TThelixFinder:RobustHelixFinder                                   9.708e-06    3.13304e-05   0.00028271    1.6872e-05    3.79566e-05      91     
-tprDe_lowP_stopTarg:TTHelixMergerDe:MergeHelices                                     1.1002e-05    1.43099e-05   2.8414e-05    1.3035e-05    3.52181e-06      91     
-mprDe_highP_stopTarg:mprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo            1.7223e-05    3.22698e-05   9.8337e-05    2.92155e-05   1.2548e-05       268    
-cprHelixDe:cprHelixDeTriggerInfoMerger:MergeTriggerInfo                              1.4508e-05    2.34291e-05   8.7256e-05    2.3034e-05    9.57915e-06      73     
-cprDe_highP:TTCalSeedFitDe:LoopHelixFit                                              0.000189993   0.000899793   0.00223514    0.000727931   0.000737862       6     
-cprDe_highP:cprDeHighPKSFilter:KalSeedFilter                                          5.49e-06     8.99764e-06   2.1922e-05     7.835e-06    3.91063e-06      39     
-tprDe_highP:TTKSFDe:LoopHelixFit                                                     0.000158744   0.00147466    0.00685648    0.00104726    0.00107918       121    
-tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTriggerInfoMerger:MergeTriggerInfo    1.0489e-05    1.64578e-05   4.3724e-05    1.5259e-05    5.08385e-06      139    
-apr_lowP_stopTarg:TTAprKSF:LoopHelixFit                                              0.000161759   0.000831562   0.00303065    0.000646636   0.000622271      209    
-apr_lowP_stopTarg:aprLowPStopTargKSFilter:KalSeedFilter                               5.711e-06    1.29004e-05   0.00012559    1.2108e-05    8.48066e-06      212    
-cprDe_lowP_stopTarg:TTCalSeedFitDe:LoopHelixFit                                      0.000161879   0.000922205   0.00355096    0.00108595    0.000652169      69     
-cprDe_lowP_stopTarg:cprDeLowPStopTargKSFilter:KalSeedFilter                           8.888e-06    1.30967e-05    2.645e-05    1.2494e-05    3.33987e-06      69     
-apr_highP_stopTarg:aprHighPStopTargKSFilter:KalSeedFilter                             4.609e-06    6.38494e-06    2.103e-05     5.45e-06     2.66794e-06      69     
-cprDe_lowP_stopTarg:cprDeLowPStopTargTriggerInfoMerger:MergeTriggerInfo              1.6121e-05    1.83356e-05   2.6681e-05    1.71425e-05   2.62967e-06      18     
-apr_lowP_stopTarg:aprLowPStopTargTriggerInfoMerger:MergeTriggerInfo                  1.6291e-05    1.8221e-05    3.0629e-05    1.7463e-05    2.91754e-06      24     
-apr_lowP_stopTarg_multiTrk:TTAprKSF:LoopHelixFit                                     0.000931851   0.00116293    0.00165094    0.00103446    0.000285266       4     
-apr_lowP_stopTarg_multiTrk:aprLowPStopTargMultiTrkKSFilter:KalSeedFilter              9.758e-06    1.13515e-05   1.3015e-05    1.13165e-05   1.27318e-06       4     
-apr_highP:aprHighPTriggerInfoMerger:MergeTriggerInfo                                 1.3606e-05    1.45583e-05   1.5109e-05    1.4709e-05    4.33133e-07       7     
-apr_highP_stopTarg:aprHighPStopTargTriggerInfoMerger:MergeTriggerInfo                1.1872e-05    1.53414e-05    2.603e-05    1.2765e-05    5.36541e-06       5     
-cprDe_highP_stopTarg:cprDeHighPStopTargKSFilter:KalSeedFilter                         4.929e-06    6.78894e-06    8.756e-06     6.783e-06    1.0965e-06       18     
-tprDe_highP:tprDeHighPTriggerInfoMerger:MergeTriggerInfo                             1.7133e-05    2.16265e-05   2.9296e-05    2.00385e-05   4.81288e-06       4     
-cprDe_highP:cprDeHighPTriggerInfoMerger:MergeTriggerInfo                             1.4988e-05    1.4988e-05    1.4988e-05    1.4988e-05         0            1     
-cprDe_highP_stopTarg:cprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo            1.3055e-05    1.3055e-05    1.3055e-05    1.3055e-05         0            1     
+source:RootInput(read)                                                               6.5144e-05    0.000154127    0.0354115    9.92445e-05   0.000392554     20000   
+caloHitRec_N0Source:artFragFromDTCEvents:ArtFragmentsFromDTCEvents                    1.097e-05    1.43006e-05   0.000292299   1.2854e-05    5.54033e-06     20000   
+caloHitRec_N0Source:caloHitRecN0SourcePS:PrescaleEvent                                8.507e-06    1.62686e-05    0.0189462    1.0801e-05    0.000156741     20000   
+minBias_CDCount:minBiasCDCountPS:PrescaleEvent                                        1.753e-06    2.53265e-06   0.000132143    2.304e-06    1.62971e-06     20000   
+minBias_SDCount:minBiasSDCountPS:PrescaleEvent                                        1.493e-06    2.01865e-06   4.5527e-05     1.833e-06    1.26945e-06     20000   
+cstCosmicTrackSeed:cstCosmicTrackSeedPS:PrescaleEvent                                 1.533e-06    2.06912e-06   0.000197008    1.864e-06    1.80968e-06     20000   
+cstTimeCluster:cstTimeClusterPS:PrescaleEvent                                         1.412e-06    1.88638e-06   2.3115e-05     1.674e-06    1.00856e-06     20000   
+caloFast_RMC:caloFastRMCPS:PrescaleEvent                                              1.503e-06    1.93457e-06   7.7738e-05     1.773e-06    1.11262e-06     20000   
+caloFast_RMC:CaloHitMakerFast:CaloHitMakerFast                                       7.6616e-05    0.000586934   0.00918097    0.000453302   0.000490414     20000   
+caloFast_RMC:CaloClusterFast:CaloClusterFast                                          9.498e-06    6.28095e-05   0.00134912    5.2361e-05    4.07235e-05     20000   
+caloFast_RMC:caloFastRMCFilter:CaloClusterCounterFilter                               6.562e-06    8.70771e-06   0.000221744    8.005e-06    3.66858e-06     20000   
+caloFast_cosmic:caloFastCosmicPS:PrescaleEvent                                        2.434e-06    3.57399e-06   0.000120701    3.276e-06    1.93558e-06     20000   
+caloFast_cosmic:caloFastCosmicFilter:CaloCosmicCalib                                  4.418e-06    6.00311e-06   7.2459e-05     5.43e-06     2.34519e-06     20000   
+caloFast_MVANNCE:caloFastMVANNCEPS:PrescaleEvent                                      1.713e-06    2.28605e-06   5.9143e-05     2.053e-06    1.31438e-06     20000   
+caloFast_MVANNCE:caloFastMVANNCEFilter:FilterEcalNNTrigger                            4.879e-06    7.7204e-06    0.000203378    7.063e-06    3.3546e-06      20000   
+caloFast_photon:caloFastPhotonPS:PrescaleEvent                                        1.553e-06    2.09311e-06   3.9286e-05     1.863e-06    1.24717e-06     20000   
+caloFast_photon:caloFastPhotonFilter:CaloLikelihood                                   4.93e-06     7.84958e-06   0.000181958    5.981e-06    4.43933e-06     20000   
+aprHelix:aprLowPStopTargPS:PrescaleEvent                                              1.693e-06    2.42902e-06   4.3804e-05     2.164e-06    1.30979e-06     20000   
+aprHelix:TTmakeSH:StrawHitReco                                                        3.65e-05     0.000486387    0.800977     0.00037141    0.00566852      20000   
+aprHelix:TTmakePH:CombineStrawHits                                                    9.098e-06    6.26041e-05   0.000811371   4.95445e-05   4.7124e-05      20000   
+aprHelix:TTflagPH:DeltaFinder                                                        8.4532e-05    0.000406741   0.00501199    0.000305109   0.00033505      20000   
+aprHelix:TTTZClusterFinder:TZClusterFinder                                           1.2534e-05    6.60114e-05   0.00208759    4.9414e-05    5.39413e-05     20000   
+aprHelix:aprHelixTCFilter:TimeClusterFilter                                           9.859e-06    1.36256e-05   0.00022499    1.2595e-05    4.43567e-06     20000   
+aprHelix:TTAprHelixFinder:AgnosticHelixFinder                                        1.0499e-05    0.000408948    0.0163288    0.000137352   0.000741243     15995   
+aprHelix:TTAprHelixMerger:MergeHelices                                               1.1312e-05    1.45001e-05   0.000232936   1.3316e-05    4.87791e-06     15995   
+aprHelix:aprHelixHSFilter:HelixFilter                                                 5.921e-06    7.54735e-06   4.5147e-05     6.913e-06    2.42759e-06     15995   
+apr_lowP_stopTarg_multiTrk:aprLowPStopTargMultiTrkPS:PrescaleEvent                    2.314e-06    3.40649e-06   0.000184813    3.126e-06    2.27451e-06     20000   
+apr_lowP_stopTarg_multiTrk:aprLowPStopTargMultiTrkTCFilter:TimeClusterFilter          7.535e-06    1.05405e-05   9.5493e-05     9.859e-06    3.12634e-06     20000   
+apr_lowP_stopTarg_multiTrk:aprLowPStopTargMultiTrkHSFilter:HelixFilter                5.231e-06    6.75522e-06   8.8199e-05     6.081e-06    2.27394e-06     15995   
+apr_lowP_stopTarg:aprLowPStopTargTCFilter:TimeClusterFilter                           6.612e-06    8.50373e-06   0.000170425    7.835e-06    2.92048e-06     20000   
+apr_lowP_stopTarg:aprLowPStopTargHSFilter:HelixFilter                                  4.9e-06     6.17223e-06   0.000199182    5.611e-06    2.9579e-06      15995   
+apr_highP:aprHighPPS:PrescaleEvent                                                    1.733e-06    2.46345e-06   8.5654e-05     2.234e-06    1.31513e-06     20000   
+apr_highP:aprHighPTCFilter:TimeClusterFilter                                          6.253e-06    8.02501e-06   0.000160096    7.305e-06    2.85238e-06     20000   
+apr_highP:aprHighPHSFilter:HelixFilter                                                4.719e-06    5.90591e-06    3.664e-05     5.35e-06     2.00586e-06     15995   
+apr_highP_stopTarg:aprHighPStopTargPS:PrescaleEvent                                   1.603e-06    2.25567e-06   4.4877e-05     2.024e-06    1.19664e-06     20000   
+apr_highP_stopTarg:aprHighPStopTargTCFilter:TimeClusterFilter                         6.562e-06    8.27485e-06   0.000192167    7.564e-06    3.09642e-06     20000   
+apr_highP_stopTarg:aprHighPStopTargHSFilter:HelixFilter                               4.549e-06    5.7609e-06    0.000321776    5.19e-06     3.44862e-06     15995   
+cprHelixUe:cprHelixUePS:PrescaleEvent                                                 1.693e-06    2.28349e-06   0.000316165    2.035e-06    2.82324e-06     20000   
+cprHelixUe:TTCalTimePeakFinderUe:CalTimePeakFinder                                    8.246e-06    1.23213e-05   0.000221323    9.778e-06    7.52334e-06     20000   
+cprHelixUe:cprHelixUeTCFilter:TimeClusterFilter                                       7.125e-06    9.00738e-06   0.000239478    8.185e-06    3.41235e-06     20000   
+cprHelixDe:cprHelixDePS:PrescaleEvent                                                 1.613e-06    2.19906e-06   2.5108e-05     1.984e-06    1.0182e-06      20000   
+cprHelixDe:TTCalTimePeakFinder:CalTimePeakFinder                                      6.572e-06    9.76317e-06   0.000160446    7.465e-06    6.49688e-06     20000   
+cprHelixDe:cprHelixDeTCFilter:TimeClusterFilter                                       6.632e-06    8.20036e-06   6.0716e-05     7.434e-06    2.64636e-06     20000   
+cprDe_lowP_stopTarg:cprDeLowPStopTargPS:PrescaleEvent                                 1.623e-06    2.24963e-06   9.5663e-05     2.004e-06    1.39612e-06     20000   
+cprDe_lowP_stopTarg:cprDeLowPStopTargTCFilter:TimeClusterFilter                       6.924e-06    8.5322e-06    8.0574e-05     7.765e-06    2.58297e-06     20000   
+cprDe_highP:cprDeHighPPS:PrescaleEvent                                                1.563e-06    2.1772e-06    0.000206124    1.924e-06    1.87378e-06     20000   
+cprDe_highP:cprDeHighPTCFilter:TimeClusterFilter                                      6.191e-06    7.79815e-06   0.000216694    7.084e-06    3.4488e-06      20000   
+cprDe_highP_stopTarg:cprDeHighPStopTargPS:PrescaleEvent                               1.572e-06    2.08279e-06   2.7753e-05     1.883e-06    1.08507e-06     20000   
+cprDe_highP_stopTarg:cprDeHighPStopTargTCFilter:TimeClusterFilter                     6.153e-06    7.54011e-06   0.000139496    6.883e-06    2.65333e-06     20000   
+tprHelixUe:tprHelixUePS:PrescaleEvent                                                 1.733e-06    2.26083e-06    3.143e-05     2.044e-06    1.09956e-06     20000   
+tprHelixUe:TTtimeClusterFinderUe:TimeClusterFinder                                   2.9577e-05    0.00146851     0.0229727    0.000876821   0.00183378      20000   
+tprHelixUe:tprHelixUeTCFilter:TimeClusterFilter                                       7.864e-06    1.33226e-05   0.000221404   1.2604e-05    4.94208e-06     20000   
+tprHelixUe:TThelixFinderUe:RobustHelixFinder                                          9.468e-06    0.000301914    0.0210934    0.000125505   0.000551092     19786   
+tprHelixUe:TTHelixMergerUe:MergeHelices                                               9.749e-06    1.6354e-05    0.000252333   1.4227e-05    6.99336e-06     19786   
+tprHelixUe:tprHelixUeHSFilter:HelixFilter                                             5.581e-06    8.73007e-06   0.000138224    7.334e-06    3.44195e-06     19786   
+tprHelixDe:tprHelixDePS:PrescaleEvent                                                 1.703e-06    3.07545e-06   5.0737e-05     2.875e-06    1.44927e-06     20000   
+tprHelixDe:TTtimeClusterFinder:TimeClusterFinder                                     2.6861e-05    0.00139451     0.0220806    0.00082088    0.00177564      20000   
+tprHelixDe:tprHelixDeTCFilter:TimeClusterFilter                                       7.233e-06    1.33158e-05   0.000203709   1.2685e-05    4.14665e-06     20000   
+tprHelixDe:TThelixFinder:RobustHelixFinder                                            7.614e-06    0.00032388     0.0238911    0.000134096   0.000595106     19813   
+tprHelixDe:TTHelixMergerDe:MergeHelices                                               8.546e-06    1.57501e-05   0.000231192   1.3737e-05    7.12873e-06     19813   
+tprHelixDe:tprHelixDeHSFilter:HelixFilter                                             4.869e-06    8.1194e-06    0.000215903    6.894e-06    3.78494e-06     19813   
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledPS:PrescaleEvent                       1.733e-06    3.06629e-06   3.2973e-05     2.875e-06    1.31503e-06     20000   
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTCFilter:TimeClusterFilter             6.654e-06    1.12131e-05   0.00107574    1.0529e-05    8.75461e-06     20000   
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledHSFilter:HelixFilter                   4.558e-06    6.40365e-06   0.000125318    5.61e-06     2.72441e-06     19813   
+tprHelixDe_ipa:tprHelixDeIpaPS:PrescaleEvent                                          1.583e-06    2.28964e-06   6.0707e-05     2.084e-06    1.20564e-06     20000   
+tprHelixDe_ipa:tprHelixDeIpaTCFilter:TimeClusterFilter                                6.642e-06    8.96264e-06   0.000235901    8.236e-06    3.68231e-06     20000   
+tprHelixDe_ipa:tprHelixDeIpaHSFilter:HelixFilter                                      4.55e-06     6.0001e-06    7.4121e-05     5.25e-06     2.2739e-06      19813   
+tprDe_lowP_stopTarg:tprDeLowPStopTargPS:PrescaleEvent                                 1.633e-06    2.25625e-06   3.8113e-05     2.033e-06    1.1617e-06      20000   
+tprDe_lowP_stopTarg:tprDeLowPStopTargTCFilter:TimeClusterFilter                       6.783e-06    8.78609e-06   0.000290496    8.036e-06    3.96348e-06     20000   
+tprDe_lowP_stopTarg:tprDeLowPStopTargHSFilter:HelixFilter                             4.809e-06    6.74887e-06   0.000180154    5.841e-06    3.0035e-06      19904   
+tprDe_highP:tprDeHighPPS:PrescaleEvent                                                1.603e-06    2.27646e-06    3.111e-05     1.983e-06    1.09774e-06     20000   
+tprDe_highP:tprDeHighPTCFilter:TimeClusterFilter                                      6.433e-06    8.72937e-06   0.000237614    7.626e-06    4.4882e-06      20000   
+tprDe_highP:tprDeHighPHSFilter:HelixFilter                                            4.618e-06    6.6807e-06    0.000173742    5.481e-06    3.22498e-06     19813   
+tprDe_highP_stopTarg:tprDeHighPStopTargPS:PrescaleEvent                               1.592e-06    2.18639e-06   0.000173371    1.943e-06    1.62769e-06     20000   
+tprDe_highP_stopTarg:tprDeHighPStopTargTCFilter:TimeClusterFilter                     6.523e-06     8.502e-06    0.000381629    7.704e-06    4.12403e-06     20000   
+tprDe_highP_stopTarg:tprDeHighPStopTargHSFilter:HelixFilter                           4.458e-06    6.25246e-06   0.000212706    5.29e-06     2.90894e-06     19813   
+mprDe_highP_stopTarg:mprDeHighPStopTargPS:PrescaleEvent                               1.513e-06    2.0746e-06    3.0778e-05     1.864e-06    1.10712e-06     20000   
+mprDe_highP_stopTarg:mprDeHighPStopTargTCFilter:TimeClusterFilter                     6.802e-06    9.94739e-06   0.000396558    8.125e-06    1.48697e-05     20000   
+mprDe_highP_stopTarg:TTRobustMultiHelixFinder:RobustMultiHelixFinder                 1.6371e-05    0.00333549     0.181536     0.00111351    0.00755684      19813   
+mprDe_highP_stopTarg:TTMprHelixMergerDe:MergeHelices                                 1.2675e-05    0.000168403    0.0053613    4.5407e-05    0.000364549     19813   
+mprDe_highP_stopTarg:mprDeHighPStopTargHSFilter:HelixFilter                           5.28e-06     2.15051e-05   0.000282801   1.6861e-05    1.62614e-05     19813   
+mprDe_highP_stopTarg:TTMprKSFDe:LoopHelixFit                                         0.000129927    0.0101876     0.082587     0.00724242    0.00943185      12188   
+mprDe_highP_stopTarg:mprDeHighPStopTargKSFilter:KalSeedFilter                         7.695e-06    2.05474e-05   0.000187869   1.7999e-05    1.01537e-05     12188   
+[art]:TriggerResults:TriggerResultInserter                                            3.617e-06    4.80617e-06   0.000227685    4.259e-06    2.84079e-06     20000   
+cprHelixUe:TTCalHelixFinderUe:CalHelixFinder                                         5.1258e-05    0.000217023   0.00274602    0.000153057   0.000193866     1456    
+cprHelixUe:TTCalHelixMergerUe:MergeHelices                                            1.054e-05    1.41551e-05   3.7641e-05    1.3395e-05    2.92447e-06     1456    
+cprHelixUe:cprHelixUeHSFilter:HelixFilter                                             5.991e-06    8.56727e-06   0.000179083    7.614e-06    5.35869e-06     1456    
+cprHelixDe:TTCalHelixFinderDe:CalHelixFinder                                         4.3703e-05    0.000218425   0.00235722    0.000150047   0.000205244     1579    
+cprHelixDe:TTCalHelixMergerDe:MergeHelices                                            9.839e-06    1.41105e-05   6.0134e-05    1.2936e-05    4.07082e-06     1579    
+cprHelixDe:cprHelixDeHSFilter:HelixFilter                                             5.63e-06     8.34222e-06   3.3595e-05     7.393e-06    2.92806e-06     1579    
+cprDe_lowP_stopTarg:cprDeLowPStopTargHSFilter:HelixFilter                             5.22e-06     7.27086e-06   3.9225e-05     6.663e-06    2.30416e-06     1579    
+cprDe_highP:cprDeHighPHSFilter:HelixFilter                                            5.16e-06     7.18652e-06   6.1969e-05     6.402e-06    2.69993e-06     1579    
+cprDe_highP_stopTarg:cprDeHighPStopTargHSFilter:HelixFilter                           4.829e-06    6.86584e-06   2.7402e-05     6.292e-06    2.19455e-06     1579    
+tprHelixDe:tprHelixDeTriggerInfoMerger:MergeTriggerInfo                              1.3456e-05    2.02341e-05   0.000149274   1.7133e-05    8.73044e-06     1413    
+tprDe_lowP_stopTarg:TTKSFDe:LoopHelixFit                                             0.000152631   0.00176774     0.0127454    0.00148804    0.00124371      1729    
+tprDe_lowP_stopTarg:tprDeLowPStopTargKSFilter:KalSeedFilter                           7.764e-06    1.43884e-05   0.000190956   1.3946e-05    6.75275e-06     1729    
+tprDe_lowP_stopTarg:tprDeLowPStopTargTriggerInfoMerger:MergeTriggerInfo              1.6291e-05    1.97727e-05   3.8304e-05     1.82e-05     4.32663e-06      166    
+aprHelix:aprHelixTriggerInfoMerger:MergeTriggerInfo                                  1.5079e-05    2.20848e-05   6.2018e-05    2.0975e-05    6.35919e-06      306    
+apr_highP:TTAprKSF:LoopHelixFit                                                      0.00017811     0.0007201    0.00282233    0.000537798   0.000560349      92     
+apr_highP:aprHighPKSFilter:KalSeedFilter                                              4.899e-06    8.38207e-06   2.6721e-05     7.699e-06    3.43491e-06      234    
+tprHelixUe:tprHelixUeTriggerInfoMerger:MergeTriggerInfo                              1.4087e-05    2.32153e-05   0.000193509   2.1466e-05    8.74451e-06     1884    
+tprDe_highP:tprDeHighPKSFilter:KalSeedFilter                                          4.769e-06    8.35562e-06   4.2962e-05     7.936e-06    3.51526e-06     1089    
+tprDe_highP_stopTarg:tprDeHighPStopTargKSFilter:KalSeedFilter                         4.678e-06    7.44585e-06   2.4808e-05     7.014e-06    2.88897e-06      695    
+tprHelixDe_ipa:tprHelixDeIpaTriggerInfoMerger:MergeTriggerInfo                        1.019e-05    1.47614e-05   4.6699e-05    1.4068e-05    4.20447e-06      543    
+tprDe_lowP_stopTarg:TThelixFinder:RobustHelixFinder                                   9.357e-06    3.59688e-05   0.000297118    1.573e-05    5.0833e-05       91     
+tprDe_lowP_stopTarg:TTHelixMergerDe:MergeHelices                                     1.0862e-05    1.37815e-05   3.3042e-05    1.3004e-05    3.24377e-06      91     
+mprDe_highP_stopTarg:mprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo            1.7332e-05    2.97505e-05   0.000288361   2.5258e-05    2.08217e-05      268    
+cprHelixDe:cprHelixDeTriggerInfoMerger:MergeTriggerInfo                              1.4818e-05    2.12007e-05   3.4487e-05    2.0279e-05    4.28284e-06      73     
+cprDe_highP:TTCalSeedFitDe:LoopHelixFit                                              0.000181558   0.000865936   0.00193099    0.000787921   0.000653971       6     
+cprDe_highP:cprDeHighPKSFilter:KalSeedFilter                                          5.26e-06     8.61905e-06   3.3734e-05     7.133e-06    5.11439e-06      39     
+tprDe_highP:TTKSFDe:LoopHelixFit                                                     0.000215923   0.00143077    0.00498736    0.00104328    0.000997848      121    
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTriggerInfoMerger:MergeTriggerInfo    1.1461e-05    1.65797e-05   4.3703e-05    1.5258e-05    5.59271e-06      139    
+apr_lowP_stopTarg:TTAprKSF:LoopHelixFit                                              0.000165857   0.000825905   0.00306199    0.000661916   0.000607809      209    
+apr_lowP_stopTarg:aprLowPStopTargKSFilter:KalSeedFilter                               6.072e-06    1.27158e-05   5.5616e-05    1.1437e-05    5.00833e-06      212    
+cprDe_lowP_stopTarg:TTCalSeedFitDe:LoopHelixFit                                      0.000159325   0.000916495   0.00359481    0.00111055    0.000660926      69     
+cprDe_lowP_stopTarg:cprDeLowPStopTargKSFilter:KalSeedFilter                           8.597e-06    1.28733e-05   5.9664e-05    1.1101e-05    6.39906e-06      69     
+apr_highP_stopTarg:aprHighPStopTargKSFilter:KalSeedFilter                             4.899e-06    6.29509e-06   2.0489e-05     5.631e-06    2.11431e-06      69     
+cprDe_lowP_stopTarg:cprDeLowPStopTargTriggerInfoMerger:MergeTriggerInfo              1.6231e-05    1.90645e-05   3.0518e-05    1.7453e-05    3.64403e-06      18     
+apr_lowP_stopTarg:aprLowPStopTargTriggerInfoMerger:MergeTriggerInfo                  1.6512e-05    1.78634e-05   2.3946e-05    1.7323e-05    1.68284e-06      24     
+apr_lowP_stopTarg_multiTrk:TTAprKSF:LoopHelixFit                                     0.000979433   0.00119012    0.00167529    0.00105287    0.000281755       4     
+apr_lowP_stopTarg_multiTrk:aprLowPStopTargMultiTrkKSFilter:KalSeedFilter              9.618e-06    1.13193e-05    1.541e-05    1.01245e-05   2.37825e-06       4     
+cprDe_highP_stopTarg:cprDeHighPStopTargKSFilter:KalSeedFilter                         5.35e-06     8.09267e-06   2.7713e-05     7.439e-06    4.88659e-06      18     
+tprDe_highP:tprDeHighPTriggerInfoMerger:MergeTriggerInfo                             1.6561e-05    1.91132e-05   2.4226e-05    1.7833e-05    3.0141e-06        4     
+cprDe_highP:cprDeHighPTriggerInfoMerger:MergeTriggerInfo                             2.5709e-05    2.5709e-05    2.5709e-05    2.5709e-05         0            1     
+cprDe_highP_stopTarg:cprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo             2.598e-05     2.598e-05     2.598e-05     2.598e-05         0            1     
+apr_highP:aprHighPTriggerInfoMerger:MergeTriggerInfo                                 2.0578e-05    2.0578e-05    2.0578e-05    2.0578e-05         0            1     
 =======================================================================================================================================================================
 DbEngine::endJob
-    Total time in reading DB: 464.403 s
+    Total time in reading DB: 0.633509 s
     Total time waiting for locks: 1e-06 s
-    Total time in locks: 232.442 s
+    Total time in locks: 0.467918 s
     valcache memory: 58065 b
   Database cache stats:
     cache nTable : 11
@@ -234,8 +233,8 @@ TrigReport        151      20000          1      19999          0 cprDe_highP
 TrigReport        160      20000         18      19982          0 cprDe_lowP_stopTarg
 TrigReport        170      20000         73      19927          0 cprHelixDe
 TrigReport        171      20000         28      19972          0 cprHelixUe
-TrigReport        180      20000          5      19995          0 apr_highP_stopTarg
-TrigReport        181      20000          7      19993          0 apr_highP
+TrigReport        180      20000          0      20000          0 apr_highP_stopTarg
+TrigReport        181      20000          1      19999          0 apr_highP
 TrigReport        190      20000         24      19976          0 apr_lowP_stopTarg
 TrigReport        191      20000          0      20000          0 apr_lowP_stopTarg_multiTrk
 TrigReport        195      20000        306      19694          0 aprHelix
@@ -284,8 +283,8 @@ TrigReport        181      15995      15995          0          0 TTAprHelixFind
 TrigReport        181      15995      15995          0          0 TTAprHelixMerger
 TrigReport        181      15995        234      15761          0 aprHighPHSFilter
 TrigReport        181        234        234          0          0 TTAprKSF
-TrigReport        181        234          7        227          0 aprHighPKSFilter
-TrigReport        181          7          7          0          0 aprHighPTriggerInfoMerger
+TrigReport        181        234          1        233          0 aprHighPKSFilter
+TrigReport        181          1          1          0          0 aprHighPTriggerInfoMerger
 
 TrigReport ---------- Modules in path: apr_highP_stopTarg ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -302,8 +301,8 @@ TrigReport        180      15995      15995          0          0 TTAprHelixFind
 TrigReport        180      15995      15995          0          0 TTAprHelixMerger
 TrigReport        180      15995         69      15926          0 aprHighPStopTargHSFilter
 TrigReport        180         69         69          0          0 TTAprKSF
-TrigReport        180         69          5         64          0 aprHighPStopTargKSFilter
-TrigReport        180          5          5          0          0 aprHighPStopTargTriggerInfoMerger
+TrigReport        180         69          0         69          0 aprHighPStopTargKSFilter
+TrigReport        180          0          0          0          0 aprHighPStopTargTriggerInfoMerger
 
 TrigReport ---------- Modules in path: apr_lowP_stopTarg ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -673,15 +672,15 @@ TrigReport      15995      15995        306      15689          0 aprHelixHSFilt
 TrigReport      20000      20000      15995       4005          0 aprHelixTCFilter
 TrigReport        306        306        306          0          0 aprHelixTriggerInfoMerger
 TrigReport      15995      15995        234      15761          0 aprHighPHSFilter
-TrigReport        234        234          7        227          0 aprHighPKSFilter
+TrigReport        234        234          1        233          0 aprHighPKSFilter
 TrigReport      20000      20000      20000          0          0 aprHighPPS
 TrigReport      15995      15995         69      15926          0 aprHighPStopTargHSFilter
-TrigReport         69         69          5         64          0 aprHighPStopTargKSFilter
+TrigReport         69         69          0         69          0 aprHighPStopTargKSFilter
 TrigReport      20000      20000      20000          0          0 aprHighPStopTargPS
 TrigReport      20000      20000      15995       4005          0 aprHighPStopTargTCFilter
-TrigReport          5          5          5          0          0 aprHighPStopTargTriggerInfoMerger
+TrigReport          0          0          0          0          0 aprHighPStopTargTriggerInfoMerger
 TrigReport      20000      20000      15995       4005          0 aprHighPTCFilter
-TrigReport          7          7          7          0          0 aprHighPTriggerInfoMerger
+TrigReport          1          1          1          0          0 aprHighPTriggerInfoMerger
 TrigReport      15995      15995        212      15783          0 aprLowPStopTargHSFilter
 TrigReport        212        212         24        188          0 aprLowPStopTargKSFilter
 TrigReport      15995      15995          4      15991          0 aprLowPStopTargMultiTrkHSFilter
@@ -776,9 +775,9 @@ TrigReport      20000      20000      19786        214          0 tprHelixUeTCFi
 TrigReport       1884       1884       1884          0          0 tprHelixUeTriggerInfoMerger
 
 TimeReport ---------- Time summary [sec] -------
-TimeReport CPU = 347.717561 Real = 636.079751
+TimeReport CPU = 342.721200 Real = 388.879740
 
 MemReport  ---------- Memory summary [base-10 MB] ------
-MemReport  VmPeak = 1526.53 VmHWM = 582.046
+MemReport  VmPeak = 1524.74 VmHWM = 581.64
 
 Art has completed and will exit with status 0.


### PR DESCRIPTION
Add an updated log file after the bug fix in the high momentum APR trigger (e- and e+ cuts were both applied to e-/e+ tracks). Additionally add repo name flexibility to the CI test. 