### PR TITLE
Add upstream track reco path

### DIFF
--- a/ci/reference_log_file.log
+++ b/ci/reference_log_file.log
@@ -1,7 +1,7 @@
    ************************** Mu2e Offline **************************
      art v3_14_03    root v6_30_04    KinKal v03_01_07
      build  /exp/mu2e/app/users/mmackenz/Yale/main
-     build  al9-prof-e28-p075    04/09/25 09:22:30
+     build  al9-prof-e28-p075    05/12/25 10:59:50
    ******************************************************************
 Conditions file: /exp/mu2e/app/users/mmackenz/Yale/main/Offline/ConditionsService/data/conditions_01.txt
 Conditions lines: 38  hash: 8098310628555253397
@@ -13,17 +13,18 @@ BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing (
 BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing ( 0x1 : Inactive )
 BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing ( 0x1 : Inactive )
 BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing ( 0x1 : Inactive )
+BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing ( 0x1 : Inactive )
 DeltaFinderAlg created
-09-Apr-2025 12:43:45 CDT  Initiating request to open input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
-09-Apr-2025 12:43:46 CDT  Opened input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
+12-May-2025 11:26:56 CDT  Initiating request to open input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
+12-May-2025 11:26:57 CDT  Opened input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
 tprHelixDeIpaHSFilter NO HELIX CUT HAS BEEN SET FOR THE HELICES WITH NEGATIVE HELICITY. IF THAT'S NOT THE DESIRED BEHAVIOUR REVIEW YOUR CONFIGUREATION!
 tprHelixDeIpaPhiScaledHSFilter NO HELIX CUT HAS BEEN SET FOR THE HELICES WITH NEGATIVE HELICITY. IF THAT'S NOT THE DESIRED BEHAVIOUR REVIEW YOUR CONFIGUREATION!
 Geometry file: /exp/mu2e/app/users/mmackenz/Yale/main/Offline/Mu2eG4/geom/geom_common.txt
-Geometry lines: 21094  hash: 1759994574127140377
+Geometry lines: 21097  hash: 2867754944553085552
 BField file: /exp/mu2e/app/users/mmackenz/Yale/main/Offline/Mu2eG4/geom/bfgeom_reco_v01.txt
 BField lines: 98  hash: 3243269116804334601
-Begin processing the 1st record. run: 1202 subRun: 0 event: 1 at 09-Apr-2025 12:44:36 CDT
-DbReader::fillValCache took 0.211491 s
+Begin processing the 1st record. run: 1202 subRun: 0 event: 1 at 12-May-2025 11:27:15 CDT
+DbReader::fillValCache took 0.241 s
 DbEngine confirmed purpose and version:
 MDC2020_best 1/3/-1
 DbEngine IoV summary
@@ -48,171 +49,176 @@ DbEngine IoV summary
              CRVSiPM       3
            CRVPhoton       3
              CRVTime       3
-DbEngine inclusive beginJob time was 0.211752 s
-Begin processing the 2nd record. run: 1202 subRun: 0 event: 2 at 09-Apr-2025 12:44:36 CDT
-Begin processing the 3rd record. run: 1202 subRun: 0 event: 3 at 09-Apr-2025 12:44:36 CDT
-Begin processing the 5th record. run: 1202 subRun: 0 event: 5 at 09-Apr-2025 12:44:37 CDT
-Begin processing the 9th record. run: 1202 subRun: 0 event: 9 at 09-Apr-2025 12:44:37 CDT
-Begin processing the 17th record. run: 1202 subRun: 0 event: 17 at 09-Apr-2025 12:44:37 CDT
-Begin processing the 33rd record. run: 1202 subRun: 0 event: 33 at 09-Apr-2025 12:44:37 CDT
-Begin processing the 65th record. run: 1202 subRun: 0 event: 65 at 09-Apr-2025 12:44:38 CDT
-Begin processing the 129th record. run: 1202 subRun: 0 event: 129 at 09-Apr-2025 12:44:39 CDT
-Begin processing the 257th record. run: 1202 subRun: 0 event: 257 at 09-Apr-2025 12:44:41 CDT
-Begin processing the 513th record. run: 1202 subRun: 0 event: 513 at 09-Apr-2025 12:44:46 CDT
-Begin processing the 1025th record. run: 1202 subRun: 0 event: 1025 at 09-Apr-2025 12:44:55 CDT
-Begin processing the 2049th record. run: 1202 subRun: 0 event: 2049 at 09-Apr-2025 12:45:14 CDT
-Begin processing the 4097th record. run: 1202 subRun: 1 event: 97 at 09-Apr-2025 12:45:50 CDT
-Begin processing the 8193rd record. run: 1202 subRun: 2 event: 193 at 09-Apr-2025 12:47:07 CDT
-09-Apr-2025 12:47:40 CDT  Closed input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
-09-Apr-2025 12:47:40 CDT  Initiating request to open input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
-09-Apr-2025 12:47:40 CDT  Opened input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
-%MSG-w GEOM:  BeginRun 09-Apr-2025 12:47:40 CDT run: 1202
+DbEngine inclusive beginJob time was 0.241236 s
+Begin processing the 2nd record. run: 1202 subRun: 0 event: 2 at 12-May-2025 11:27:16 CDT
+Begin processing the 3rd record. run: 1202 subRun: 0 event: 3 at 12-May-2025 11:27:16 CDT
+Begin processing the 5th record. run: 1202 subRun: 0 event: 5 at 12-May-2025 11:27:16 CDT
+Begin processing the 9th record. run: 1202 subRun: 0 event: 9 at 12-May-2025 11:27:16 CDT
+Begin processing the 17th record. run: 1202 subRun: 0 event: 17 at 12-May-2025 11:27:16 CDT
+Begin processing the 33rd record. run: 1202 subRun: 0 event: 33 at 12-May-2025 11:27:17 CDT
+Begin processing the 65th record. run: 1202 subRun: 0 event: 65 at 12-May-2025 11:27:17 CDT
+Begin processing the 129th record. run: 1202 subRun: 0 event: 129 at 12-May-2025 11:27:18 CDT
+Begin processing the 257th record. run: 1202 subRun: 0 event: 257 at 12-May-2025 11:27:20 CDT
+Begin processing the 513th record. run: 1202 subRun: 0 event: 513 at 12-May-2025 11:27:25 CDT
+Begin processing the 1025th record. run: 1202 subRun: 0 event: 1025 at 12-May-2025 11:27:33 CDT
+Begin processing the 2049th record. run: 1202 subRun: 0 event: 2049 at 12-May-2025 11:27:50 CDT
+Begin processing the 4097th record. run: 1202 subRun: 1 event: 97 at 12-May-2025 11:28:24 CDT
+Begin processing the 8193rd record. run: 1202 subRun: 2 event: 193 at 12-May-2025 11:29:37 CDT
+12-May-2025 11:30:08 CDT  Closed input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
+12-May-2025 11:30:08 CDT  Initiating request to open input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
+12-May-2025 11:30:09 CDT  Opened input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
+%MSG-w GEOM:  BeginRun 12-May-2025 11:30:09 CDT run: 1202
 This test version does not change geometry on run boundaries.
 %MSG
 This test version does not change geometry on run boundaries.
-Begin processing the 16385th record. run: 1202 subRun: 4 event: 385 at 09-Apr-2025 12:49:40 CDT
-09-Apr-2025 12:50:49 CDT  Closed input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
+Begin processing the 16385th record. run: 1202 subRun: 4 event: 385 at 12-May-2025 11:31:59 CDT
+12-May-2025 11:33:03 CDT  Closed input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
 
 =======================================================================================================================================================================
 TimeTracker printout (sec)                                                               Min           Avg           Max         Median          RMS         nEvts   
 =======================================================================================================================================================================
-Full event                                                                           0.00106523     0.0184695     0.812854      0.0101979     0.0241672      20000   
+Full event                                                                           0.00106745     0.0172308     0.822398     0.00929348     0.0226882      20000   
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-source:RootInput(read)                                                               6.6767e-05    0.000210847    0.0520085    0.000134247   0.000574048     20000   
-caloHitRec_N0Source:processDTCAndCFOEvents:ProcessDTCAndCFOEvents                    1.6492e-05    2.63277e-05   0.000677334   2.3305e-05    1.19317e-05     20000   
-caloHitRec_N0Source:caloHitRecN0SourcePS:PrescaleEvent                                8.966e-06    2.23397e-05   0.00686662     1.571e-05    8.95285e-05     20000   
-minBias_CDCount:minBiasCDCountPS:PrescaleEvent                                        1.853e-06    3.42755e-06   8.4391e-05     2.905e-06    2.53662e-06     20000   
-minBias_SDCount:minBiasSDCountPS:PrescaleEvent                                        1.513e-06    2.42125e-06    7.292e-05     2.034e-06    1.62613e-06     20000   
-cstCosmicTrackSeed:cstCosmicTrackSeedPS:PrescaleEvent                                 1.513e-06    2.75158e-06   0.000102266    2.304e-06    2.22232e-06     20000   
-cstTimeCluster:cstTimeClusterPS:PrescaleEvent                                         1.422e-06    2.62562e-06   0.000419402    2.204e-06    4.40341e-06     20000   
-caloFast_RMC:caloFastRMCPS:PrescaleEvent                                              1.493e-06    2.47778e-06   0.000292097    2.084e-06    2.64683e-06     20000   
-caloFast_RMC:CaloHitMakerFast:CaloHitMakerFast                                       9.3078e-05    0.000691293    0.0154711    0.00053134    0.000614535     20000   
-caloFast_RMC:CaloClusterFast:CaloClusterFast                                          9.338e-06    7.6424e-05    0.000807403   6.43235e-05   4.92129e-05     20000   
-caloFast_RMC:caloFastRMCFilter:CaloClusterCounterFilter                               6.672e-06    1.10824e-05   0.000832973    9.498e-06    8.34964e-06     20000   
-caloFast_cosmic:caloFastCosmicPS:PrescaleEvent                                        2.685e-06    4.93505e-06   0.000369035    4.067e-06    4.6274e-06      20000   
-caloFast_cosmic:caloFastCosmicFilter:CaloCosmicCalib                                  4.468e-06    7.72713e-06   0.00066947     6.412e-06    7.50548e-06     20000   
-caloFast_MVANNCE:caloFastMVANNCEPS:PrescaleEvent                                      1.793e-06    3.07382e-06   0.000329439    2.585e-06    3.91341e-06     20000   
-caloFast_MVANNCE:caloFastMVANNCEFilter:FilterEcalNNTrigger                            5.07e-06     1.04822e-05   0.000196186    9.007e-06    5.56749e-06     20000   
-caloFast_photon:caloFastPhotonPS:PrescaleEvent                                        1.773e-06    2.88943e-06   0.000343817    2.404e-06    2.99579e-06     20000   
-caloFast_photon:caloFastPhotonFilter:CaloLikelihood                                   5.099e-06    1.07912e-05    0.0003711    7.9045e-06    7.89328e-06     20000   
-aprHelix:aprLowPStopTargPS:PrescaleEvent                                              1.753e-06    3.16808e-06   8.5533e-05     2.715e-06    2.20894e-06     20000   
-aprHelix:TTmakeSH:StrawHitReco                                                       4.6228e-05    0.000619484    0.794616     0.000497731   0.00562928      20000   
-aprHelix:TTmakePH:CombineStrawHits                                                    9.808e-06    7.1521e-05    0.000782807   5.63575e-05   5.39551e-05     20000   
-aprHelix:TTflagPH:DeltaFinder                                                        9.3459e-05    0.000524163   0.00963112    0.000424798   0.000383204     20000   
-aprHelix:TTTZClusterFinder:TZClusterFinder                                           1.2713e-05    7.64133e-05   0.000799789   5.85625e-05   5.99314e-05     20000   
-aprHelix:aprHelixTCFilter:TimeClusterFilter                                            9.9e-06     1.66798e-05   0.000733171   1.40265e-05   1.0319e-05      20000   
-aprHelix:TTAprHelixFinder:AgnosticHelixFinder                                         1.056e-05    0.000448036    0.0171176    0.000152781   0.00081524      15995   
-aprHelix:TTAprHelixMerger:MergeHelices                                               1.1511e-05    1.88954e-05   0.000457094   1.5971e-05    1.0674e-05      15995   
-aprHelix:aprHelixHSFilter:HelixFilter                                                 5.871e-06    9.6678e-06    0.000351371    8.235e-06    5.22644e-06     15995   
-apr_lowP_multiHelix:aprLowPMultiHelixPS:PrescaleEvent                                 2.535e-06    4.47415e-06   0.000333958    3.907e-06    3.36839e-06     20000   
-apr_lowP_multiHelix:aprLowPMultiHelixTCFilter:TimeClusterFilter                       7.816e-06    1.31674e-05   0.000206684   1.1462e-05    5.72672e-06     20000   
-apr_lowP_multiHelix:aprLowPMultiHelixHSFilter:HelixFilter                             5.27e-06     8.47761e-06   0.000242013    7.234e-06    4.68507e-06     15995   
-apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkPS:PrescaleEvent                  1.883e-06    3.42699e-06   6.4453e-05     2.966e-06    2.11895e-06     20000   
-apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkTCFilter:TimeClusterFilter        7.104e-06    1.12103e-05   0.000285445    9.498e-06    5.48587e-06     20000   
-apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkHSFilter:HelixFilter               5.1e-06     7.94298e-06   0.000252503    6.673e-06    4.6884e-06      15995   
-apr_lowP_stopTarg:aprLowPStopTargTCFilter:TimeClusterFilter                           6.773e-06    1.05981e-05   0.000390426    8.977e-06    5.70216e-06     20000   
-apr_lowP_stopTarg:aprLowPStopTargHSFilter:HelixFilter                                 4.609e-06    7.39839e-06   0.000132744    6.352e-06    3.58705e-06     15995   
-apr_highP:aprHighPPS:PrescaleEvent                                                    1.773e-06    3.1454e-06    0.000137102    2.675e-06    2.24537e-06     20000   
-apr_highP:aprHighPTCFilter:TimeClusterFilter                                          6.653e-06    1.0134e-05    0.000141671    8.466e-06    4.90245e-06     20000   
-apr_highP:aprHighPHSFilter:HelixFilter                                                4.809e-06    7.64391e-06   0.000103909    6.492e-06    3.98512e-06     15995   
-apr_highP_stopTarg:aprHighPStopTargPS:PrescaleEvent                                   1.693e-06    2.89277e-06   0.000112374   2.4055e-06    2.1046e-06      20000   
-apr_highP_stopTarg:aprHighPStopTargTCFilter:TimeClusterFilter                         6.502e-06    1.01217e-05   0.000495627   8.3965e-06    6.48408e-06     20000   
-apr_highP_stopTarg:aprHighPStopTargHSFilter:HelixFilter                               4.779e-06    7.48082e-06   0.000120811    6.412e-06    3.83996e-06     15995   
-cprHelixUe:cprHelixUePS:PrescaleEvent                                                 1.843e-06    3.00264e-06   9.4851e-05     2.505e-06    1.99418e-06     20000   
-cprHelixUe:TTCalTimePeakFinderUe:CalTimePeakFinder                                    8.377e-06    1.5856e-05    0.000793236   1.2634e-05    1.22275e-05     20000   
-cprHelixUe:cprHelixUeTCFilter:TimeClusterFilter                                       7.235e-06    1.1211e-05    0.00813249     9.177e-06    5.76231e-05     20000   
-cprHelixDe:cprHelixDePS:PrescaleEvent                                                 1.854e-06    3.19387e-06   6.0446e-05     2.755e-06    2.05996e-06     20000   
-cprHelixDe:TTCalTimePeakFinder:CalTimePeakFinder                                      6.752e-06    1.20949e-05   0.00415236     8.726e-06    3.25802e-05     20000   
-cprHelixDe:cprHelixDeTCFilter:TimeClusterFilter                                       7.003e-06    1.03095e-05   0.000155076    8.696e-06    4.90532e-06     20000   
-cprDe_lowP_stopTarg:cprDeLowPStopTargPS:PrescaleEvent                                 1.763e-06    3.0128e-06    0.000119698    2.545e-06    2.05502e-06     20000   
-cprDe_lowP_stopTarg:cprDeLowPStopTargTCFilter:TimeClusterFilter                       7.003e-06    1.03317e-05   0.000472323    8.636e-06    5.85982e-06     20000   
-cprDe_highP:cprDeHighPPS:PrescaleEvent                                                1.803e-06    3.21067e-06   0.000116693    2.756e-06    2.35771e-06     20000   
-cprDe_highP:cprDeHighPTCFilter:TimeClusterFilter                                      6.622e-06    9.98946e-06   0.00018843     8.405e-06    4.85503e-06     20000   
-cprDe_highP_stopTarg:cprDeHighPStopTargPS:PrescaleEvent                               1.664e-06    2.83631e-06   7.9843e-05     2.405e-06    1.90567e-06     20000   
-cprDe_highP_stopTarg:cprDeHighPStopTargTCFilter:TimeClusterFilter                     6.142e-06    9.49296e-06   0.000170185    7.955e-06    4.79834e-06     20000   
-tprHelixUe:tprHelixUePS:PrescaleEvent                                                 1.814e-06    3.05428e-06   0.000254126    2.445e-06    2.64278e-06     20000   
-tprHelixUe:TTtimeClusterFinderUe:TimeClusterFinder                                   3.0468e-05    0.00161348     0.033699      0.0009545    0.00206803      20000   
-tprHelixUe:tprHelixUeTCFilter:TimeClusterFilter                                       8.046e-06    1.68599e-05   0.00118811    1.4869e-05    1.39125e-05     20000   
-tprHelixUe:TThelixFinderUe:RobustHelixFinder                                          1.067e-05    0.000334938    0.0210074    0.000146871   0.000597513     19786   
-tprHelixUe:TTHelixMergerUe:MergeHelices                                               1.009e-05    2.06357e-05   0.00118718    1.7363e-05    1.45239e-05     19786   
-tprHelixUe:tprHelixUeHSFilter:HelixFilter                                             5.791e-06    1.10941e-05   0.000781202    9.498e-06    7.70886e-06     19786   
-tprHelixDe:tprHelixDePS:PrescaleEvent                                                 1.944e-06    4.18784e-06   0.000675602    3.687e-06    5.21762e-06     20000   
-tprHelixDe:TTtimeClusterFinder:TimeClusterFinder                                     2.7122e-05    0.00154067     0.0334753    0.000894705   0.00201955      20000   
-tprHelixDe:tprHelixDeTCFilter:TimeClusterFilter                                       7.715e-06    1.71718e-05   0.000409293    1.533e-05    8.28239e-06     20000   
-tprHelixDe:TThelixFinder:RobustHelixFinder                                            8.397e-06    0.000352091    0.0178239    0.000149254   0.000629223     19813   
-tprHelixDe:TTHelixMergerDe:MergeHelices                                               9.117e-06    1.95944e-05   0.000404232   1.6481e-05    1.13759e-05     19813   
-tprHelixDe:tprHelixDeHSFilter:HelixFilter                                             5.27e-06     1.0559e-05    0.000517158    9.016e-06    7.32528e-06     19813   
-tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledPS:PrescaleEvent                       1.903e-06    4.09862e-06   8.0033e-05     3.567e-06    2.23674e-06     20000   
-tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTCFilter:TimeClusterFilter             6.674e-06    1.30955e-05   0.000222505   1.1522e-05    5.81226e-06     20000   
-tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledHSFilter:HelixFilter                   4.789e-06    8.16192e-06   0.000342765    6.873e-06    5.35264e-06     19813   
-tprHelixDe_ipa:tprHelixDeIpaPS:PrescaleEvent                                          1.773e-06    3.18254e-06    7.828e-05     2.725e-06    2.05408e-06     20000   
-tprHelixDe_ipa:tprHelixDeIpaTCFilter:TimeClusterFilter                                6.532e-06    1.1111e-05    0.000981756    9.297e-06    9.66867e-06     20000   
-tprHelixDe_ipa:tprHelixDeIpaHSFilter:HelixFilter                                      4.489e-06    7.46185e-06   0.000208679    6.272e-06    4.33856e-06     19813   
-tprDe_lowP_stopTarg:tprDeLowPStopTargPS:PrescaleEvent                                 1.703e-06    2.92684e-06   0.000204621    2.435e-06    2.8931e-06      20000   
-tprDe_lowP_stopTarg:tprDeLowPStopTargTCFilter:TimeClusterFilter                       6.843e-06    1.12477e-05   0.000393592    9.458e-06    7.21431e-06     20000   
-tprDe_lowP_stopTarg:tprDeLowPStopTargHSFilter:HelixFilter                             4.999e-06    8.8915e-06    0.000799289    7.565e-06    8.20319e-06     19904   
-tprDe_highP:tprDeHighPPS:PrescaleEvent                                                1.723e-06    3.15309e-06    8.369e-05     2.585e-06    2.38483e-06     20000   
-tprDe_highP:tprDeHighPTCFilter:TimeClusterFilter                                      6.843e-06    1.12381e-05   0.00203223     9.147e-06    1.53639e-05     20000   
-tprDe_highP:tprDeHighPHSFilter:HelixFilter                                            4.658e-06    8.33466e-06   0.000554419    6.682e-06    7.43555e-06     19813   
-tprDe_highP_stopTarg:tprDeHighPStopTargPS:PrescaleEvent                               1.663e-06    2.89559e-06   9.6855e-05     2.405e-06    2.22744e-06     20000   
-tprDe_highP_stopTarg:tprDeHighPStopTargTCFilter:TimeClusterFilter                     6.362e-06    1.06269e-05   0.000320393    8.877e-06    6.02857e-06     20000   
-tprDe_highP_stopTarg:tprDeHighPStopTargHSFilter:HelixFilter                           4.528e-06    7.98316e-06   0.000349879    6.673e-06    5.43216e-06     19813   
-mprDe_highP_stopTarg:mprDeHighPStopTargPS:PrescaleEvent                               1.663e-06    2.85936e-06   7.7468e-05     2.404e-06    1.89874e-06     20000   
-mprDe_highP_stopTarg:mprDeHighPStopTargTCFilter:TimeClusterFilter                     6.853e-06    1.24128e-05   0.000897115    9.709e-06    1.81342e-05     20000   
-mprDe_highP_stopTarg:TTRobustMultiHelixFinder:RobustMultiHelixFinder                 1.7333e-05    0.00351811     0.181352     0.00117332    0.00801897      19813   
-mprDe_highP_stopTarg:TTMprHelixMergerDe:MergeHelices                                 1.2685e-05    0.000187792   0.00610811    5.3703e-05    0.000400452     19813   
-mprDe_highP_stopTarg:mprDeHighPStopTargHSFilter:HelixFilter                           5.29e-06     2.55867e-05   0.000525053   1.9847e-05    2.06947e-05     19813   
-mprDe_highP_stopTarg:TTMprKSFDe:LoopHelixFit                                         0.000181107    0.0111262     0.107789     0.00783714     0.010404       12188   
-mprDe_highP_stopTarg:mprDeHighPStopTargKSFilter:KalSeedFilter                         8.265e-06    2.91457e-05   0.00290779    2.4317e-05    3.28111e-05     12188   
-[art]:TriggerResults:TriggerResultInserter                                            3.607e-06    6.62194e-06   0.000164315    5.371e-06    3.94449e-06     20000   
-cprHelixUe:TTCalHelixFinderUe:CalHelixFinder                                         6.3752e-05    0.000251058   0.00290892    0.000181047   0.000210903     1456    
-cprHelixUe:TTCalHelixMergerUe:MergeHelices                                           1.1161e-05    1.81747e-05   0.00036574    1.5359e-05    1.21386e-05     1456    
-cprHelixUe:cprHelixUeHSFilter:HelixFilter                                             6.332e-06    1.01998e-05   5.9434e-05    8.7365e-06    4.34828e-06     1456    
-cprHelixDe:TTCalHelixFinderDe:CalHelixFinder                                         4.7882e-05    0.000242112   0.00256591    0.000167951   0.000222025     1579    
-cprHelixDe:TTCalHelixMergerDe:MergeHelices                                            1.061e-05    1.65664e-05    5.719e-05    1.4567e-05    5.64773e-06     1579    
-cprHelixDe:cprHelixDeHSFilter:HelixFilter                                             6.112e-06    9.96493e-06    7.346e-05     8.536e-06    4.33186e-06     1579    
-cprDe_lowP_stopTarg:cprDeLowPStopTargHSFilter:HelixFilter                              5.7e-06     9.91082e-06    6.263e-05     8.656e-06    4.19859e-06     1579    
-cprDe_highP:cprDeHighPHSFilter:HelixFilter                                            5.139e-06    8.78577e-06   5.2581e-05     7.524e-06    3.75937e-06     1579    
-cprDe_highP_stopTarg:cprDeHighPStopTargHSFilter:HelixFilter                           5.191e-06    8.51291e-06   4.4445e-05     7.174e-06    3.70277e-06     1579    
-tprHelixDe:tprHelixDeTriggerInfoMerger:MergeTriggerInfo                              1.4078e-05    2.82377e-05   0.000191296   2.5589e-05    1.31513e-05     1413    
-tprDe_lowP_stopTarg:TTKSFDe:LoopHelixFit                                             0.000158623   0.00198742     0.0137878    0.00166092    0.00139258      1729    
-tprDe_lowP_stopTarg:tprDeLowPStopTargKSFilter:KalSeedFilter                           8.125e-06    1.92443e-05    7.301e-05    1.7765e-05    7.31522e-06     1729    
-tprDe_lowP_stopTarg:tprDeLowPStopTargTriggerInfoMerger:MergeTriggerInfo              1.7162e-05    2.34005e-05   5.9142e-05    2.0168e-05    7.10666e-06      167    
-aprHelix:aprHelixTriggerInfoMerger:MergeTriggerInfo                                  1.7353e-05    3.4072e-05    0.000113647   3.16005e-05   1.17257e-05      306    
-apr_highP:TTAprKSF:LoopHelixFit                                                      0.00018842    0.000815737   0.00311086    0.000650763   0.00059663       92     
-apr_highP:aprHighPKSFilter:KalSeedFilter                                              5.23e-06     1.08586e-05   4.5909e-05     9.228e-06    6.29688e-06      234    
-tprHelixUe:tprHelixUeTriggerInfoMerger:MergeTriggerInfo                              1.5779e-05    3.45047e-05   0.000786584   3.11295e-05   2.13286e-05     1884    
-tprDe_highP:tprDeHighPKSFilter:KalSeedFilter                                          5.18e-06     1.05139e-05   7.1307e-05     9.067e-06     5.839e-06      1089    
-tprDe_highP_stopTarg:tprDeHighPStopTargKSFilter:KalSeedFilter                         4.709e-06    8.85881e-06   5.4355e-05     7.914e-06    4.29292e-06      695    
-mprDe_highP_stopTarg:mprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo            1.8496e-05    5.03342e-05   0.000385378   4.5567e-05    2.96152e-05      265    
-tprHelixDe_ipa:tprHelixDeIpaTriggerInfoMerger:MergeTriggerInfo                       1.0409e-05    1.89387e-05   8.4692e-05     1.584e-05    9.53222e-06      543    
-tprDe_lowP_stopTarg:TThelixFinder:RobustHelixFinder                                   9.568e-06    3.46775e-05   0.00030354    1.8906e-05    4.15514e-05      91     
-tprDe_lowP_stopTarg:TTHelixMergerDe:MergeHelices                                     1.0841e-05    1.53524e-05   3.7792e-05    1.3746e-05    4.66446e-06      91     
-cprHelixDe:cprHelixDeTriggerInfoMerger:MergeTriggerInfo                               1.53e-05     3.28848e-05   7.5595e-05    3.0389e-05    1.25625e-05      73     
-cprDe_highP:TTCalSeedFitDe:LoopHelixFit                                              0.000196485   0.000855766   0.00189998    0.000755754   0.000631428       6     
-cprDe_highP:cprDeHighPKSFilter:KalSeedFilter                                          5.871e-06    1.09547e-05   3.9145e-05     8.626e-06    6.25355e-06      39     
-tprDe_highP:TTKSFDe:LoopHelixFit                                                     0.000294332   0.00156674    0.00486716    0.00116738     0.0010467       121    
-tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTriggerInfoMerger:MergeTriggerInfo    1.1912e-05    2.10214e-05   7.7368e-05    1.7263e-05    1.05142e-05      139    
-apr_lowP_stopTarg:TTAprKSF:LoopHelixFit                                              0.000164705   0.000888948   0.00336865    0.000686753   0.000657058      204    
-apr_lowP_stopTarg:aprLowPStopTargKSFilter:KalSeedFilter                               5.751e-06    1.6201e-05    6.5826e-05    1.4403e-05    7.21349e-06      212    
-cprDe_lowP_stopTarg:TTCalSeedFitDe:LoopHelixFit                                      0.000197628   0.00102742    0.00354912    0.00114372    0.000721655      69     
-cprDe_lowP_stopTarg:cprDeLowPStopTargKSFilter:KalSeedFilter                           8.737e-06    1.72534e-05   4.0829e-05     1.551e-05    6.76529e-06      69     
-apr_highP_stopTarg:aprHighPStopTargKSFilter:KalSeedFilter                             5.32e-06     7.13662e-06   1.5248e-05     6.143e-06    2.17758e-06      69     
-cprDe_lowP_stopTarg:cprDeLowPStopTargTriggerInfoMerger:MergeTriggerInfo              1.7092e-05    2.11178e-05   2.9276e-05    1.89215e-05   4.0097e-06       18     
-apr_lowP_multiHelix:TTAprKSF:LoopHelixFit                                            0.000694177   0.00164528    0.00286469    0.00131242    0.000700628       9     
-apr_lowP_multiHelix:aprLowPMultiHelixKSFilter:KalSeedFilter                          1.0701e-05    1.81206e-05    2.582e-05    1.9648e-05    5.41418e-06       9     
-apr_lowP_stopTarg:aprLowPStopTargTriggerInfoMerger:MergeTriggerInfo                  1.7915e-05    2.08269e-05    2.624e-05    1.9432e-05    2.85523e-06      24     
-apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkKSFilter:KalSeedFilter            7.846e-06    1.2907e-05     1.61e-05     1.3841e-05    3.06405e-06       4     
-cprDe_highP_stopTarg:cprDeHighPStopTargKSFilter:KalSeedFilter                         5.38e-06     8.64867e-06   1.6472e-05     8.676e-06    2.79308e-06      18     
-tprDe_highP:tprDeHighPTriggerInfoMerger:MergeTriggerInfo                             1.8666e-05    2.46247e-05   3.8433e-05     2.07e-05     8.06485e-06       4     
-cprDe_highP:cprDeHighPTriggerInfoMerger:MergeTriggerInfo                             2.9145e-05    2.9145e-05    2.9145e-05    2.9145e-05         0            1     
-cprDe_highP_stopTarg:cprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo            1.7714e-05    1.7714e-05    1.7714e-05    1.7714e-05         0            1     
-apr_highP:aprHighPTriggerInfoMerger:MergeTriggerInfo                                 1.6202e-05    1.6202e-05    1.6202e-05    1.6202e-05         0            1     
+source:RootInput(read)                                                               6.9573e-05    0.000465849    0.0708877    0.000108517    0.0035213      20000   
+caloHitRec_N0Source:processDTCAndCFOEvents:ProcessDTCAndCFOEvents                     1.63e-05     2.20164e-05   0.000601789   1.9307e-05    9.41764e-06     20000   
+caloHitRec_N0Source:caloHitRecN0SourcePS:PrescaleEvent                                8.948e-06    8.19277e-05    0.0977973    1.1962e-05    0.00175531      20000   
+minBias_CDCount:minBiasCDCountPS:PrescaleEvent                                        1.914e-06    2.84456e-06   0.000164073    2.485e-06    1.9361e-06      20000   
+minBias_SDCount:minBiasSDCountPS:PrescaleEvent                                        1.493e-06    2.23948e-06   0.000381469    1.893e-06    3.33922e-06     20000   
+cstCosmicTrackSeed:cstCosmicTrackSeedPS:PrescaleEvent                                 1.492e-06    2.28157e-06    5.21e-05      1.974e-06    1.32694e-06     20000   
+cstTimeCluster:cstTimeClusterPS:PrescaleEvent                                         1.422e-06    2.06323e-06   6.8901e-05     1.763e-06    1.30095e-06     20000   
+caloFast_RMC:caloFastRMCPS:PrescaleEvent                                              1.513e-06    2.18397e-06   6.0908e-05     1.884e-06    1.37122e-06     20000   
+caloFast_RMC:CaloHitMakerFast:CaloHitMakerFast                                       7.7218e-05    0.000608949    0.0836148    0.000458021   0.00161397      20000   
+caloFast_RMC:CaloClusterFast:CaloClusterFast                                          1.024e-05    6.98682e-05   0.000987808   5.8061e-05    4.59021e-05     20000   
+caloFast_RMC:caloFastRMCFilter:CaloClusterCounterFilter                               6.803e-06    9.62603e-06   0.000881454    8.376e-06    1.02537e-05     20000   
+caloFast_cosmic:caloFastCosmicPS:PrescaleEvent                                        2.514e-06    3.84591e-06   6.9192e-05     3.467e-06    1.79319e-06     20000   
+caloFast_cosmic:caloFastCosmicFilter:CaloCosmicCalib                                  4.348e-06    6.28639e-06   0.000524082    5.432e-06    5.30379e-06     20000   
+caloFast_MVANNCE:caloFastMVANNCEPS:PrescaleEvent                                      1.693e-06    2.38632e-06   3.9186e-05     2.074e-06    1.26885e-06     20000   
+caloFast_MVANNCE:caloFastMVANNCEFilter:FilterEcalNNTrigger                            4.939e-06    8.45829e-06   0.000852639    7.454e-06    7.80765e-06     20000   
+caloFast_photon:caloFastPhotonPS:PrescaleEvent                                        1.713e-06    2.47565e-06   0.000304903    2.134e-06    2.52226e-06     20000   
+caloFast_photon:caloFastPhotonFilter:CaloLikelihood                                   4.98e-06     9.29646e-06   0.00102268     6.593e-06    1.12125e-05     20000   
+aprHelix:aprLowPStopTargPS:PrescaleEvent                                              1.824e-06    2.8216e-06    3.9616e-05     2.435e-06    1.55413e-06     20000   
+aprHelix:TTmakeSH:StrawHitReco                                                       3.9175e-05    0.000538657    0.811855     0.000425207   0.00574504      20000   
+aprHelix:TTmakePH:CombineStrawHits                                                    9.479e-06    6.63971e-05   0.00106459    5.0997e-05    5.44271e-05     20000   
+aprHelix:TTflagPH:DeltaFinder                                                        8.4522e-05     0.0004838    0.00435946    0.000362218   0.000394321     20000   
+aprHelix:TTTZClusterFinder:TZClusterFinder                                           1.2545e-05    6.85212e-05   0.000943052   5.1739e-05    5.50453e-05     20000   
+aprHelix:aprHelixTCFilter:TimeClusterFilter                                          1.0089e-05    1.44716e-05   0.000720697   1.2955e-05    7.21784e-06     20000   
+aprHelix:TTAprHelixFinder:AgnosticHelixFinder                                         1.047e-05    0.00041037     0.0161519    0.000140168   0.00074968      15995   
+aprHelix:TTAprHelixMerger:MergeHelices                                               1.1442e-05    1.56983e-05   0.000970886   1.3997e-05    1.14674e-05     15995   
+aprHelix:aprHelixHSFilter:HelixFilter                                                 5.991e-06    8.26798e-06   0.000358134    7.305e-06    4.89481e-06     15995   
+apr_lowP_multiHelix:aprLowPMultiHelixPS:PrescaleEvent                                 2.455e-06    4.05696e-06   0.000321183    3.556e-06    3.77608e-06     20000   
+apr_lowP_multiHelix:aprLowPMultiHelixTCFilter:TimeClusterFilter                       7.675e-06    1.13484e-05   0.000231021    1.044e-05    4.32759e-06     20000   
+apr_lowP_multiHelix:aprLowPMultiHelixHSFilter:HelixFilter                             5.29e-06     7.23584e-06   0.000946981    6.322e-06    7.9358e-06      15995   
+apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkPS:PrescaleEvent                  1.764e-06    2.77728e-06   5.1749e-05     2.365e-06    1.50139e-06     20000   
+apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkTCFilter:TimeClusterFilter        6.853e-06    9.64318e-06   0.000860014    8.567e-06    7.3464e-06      20000   
+apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkHSFilter:HelixFilter              5.22e-06     6.96981e-06   0.000102466    6.132e-06    2.76577e-06     15995   
+apr_lowP_stopTarg:aprLowPStopTargTCFilter:TimeClusterFilter                           6.572e-06    8.81252e-06   0.000220131   7.8555e-06    3.69388e-06     20000   
+apr_lowP_stopTarg:aprLowPStopTargHSFilter:HelixFilter                                 4.749e-06    6.33646e-06   8.6205e-05     5.591e-06    2.41912e-06     15995   
+apr_ue_highP:aprUeHighPPS:PrescaleEvent                                               1.733e-06    2.62041e-06   0.000205172    2.254e-06    2.19852e-06     20000   
+apr_ue_highP:aprUeHighPTCFilter:TimeClusterFilter                                     6.222e-06    8.55137e-06   0.000197107    7.604e-06    3.43045e-06     20000   
+apr_ue_highP:aprUeHighPHSFilter:HelixFilter                                           4.679e-06    6.3365e-06    0.000323989    5.561e-06    3.57217e-06     15995   
+apr_highP:aprHighPPS:PrescaleEvent                                                    1.783e-06    2.49619e-06    7.847e-05     2.214e-06    1.34502e-06     20000   
+apr_highP:aprHighPTCFilter:TimeClusterFilter                                          6.432e-06    8.68716e-06   0.000197377    7.664e-06    3.87577e-06     20000   
+apr_highP:aprHighPHSFilter:HelixFilter                                                4.769e-06    6.33135e-06   0.000111503    5.511e-06    2.66822e-06     15995   
+apr_highP_stopTarg:aprHighPStopTargPS:PrescaleEvent                                   1.753e-06    2.41481e-06   3.2131e-05     2.115e-06    1.18929e-06     20000   
+apr_highP_stopTarg:aprHighPStopTargTCFilter:TimeClusterFilter                         6.222e-06    8.33484e-06   0.000213729    7.385e-06    3.95668e-06     20000   
+apr_highP_stopTarg:aprHighPStopTargHSFilter:HelixFilter                               4.679e-06    6.2526e-06    9.6764e-05     5.43e-06     2.55235e-06     15995   
+cprHelixUe:cprHelixUePS:PrescaleEvent                                                 1.803e-06    2.51551e-06   5.6188e-05     2.194e-06    1.35198e-06     20000   
+cprHelixUe:TTCalTimePeakFinderUe:CalTimePeakFinder                                    7.955e-06    1.30227e-05   0.000885082   1.0009e-05    1.01059e-05     20000   
+cprHelixUe:cprHelixUeTCFilter:TimeClusterFilter                                       7.144e-06    9.42404e-06   0.000831148    8.327e-06    6.76251e-06     20000   
+cprHelixDe:cprHelixDePS:PrescaleEvent                                                 1.753e-06    2.58969e-06   0.000211124    2.245e-06    2.38589e-06     20000   
+cprHelixDe:TTCalTimePeakFinder:CalTimePeakFinder                                      6.453e-06    1.03094e-05   0.000999571    7.614e-06    1.02266e-05     20000   
+cprHelixDe:cprHelixDeTCFilter:TimeClusterFilter                                       6.502e-06    8.56258e-06   0.000233677    7.524e-06    4.05456e-06     20000   
+cprDe_lowP_stopTarg:cprDeLowPStopTargPS:PrescaleEvent                                 1.754e-06    2.64156e-06   0.000197307    2.234e-06    2.31999e-06     20000   
+cprDe_lowP_stopTarg:cprDeLowPStopTargTCFilter:TimeClusterFilter                       6.483e-06    8.67443e-06   0.000199862    7.545e-06    3.37855e-06     20000   
+cprDe_highP:cprDeHighPPS:PrescaleEvent                                                1.633e-06    2.39073e-06   3.0789e-05     2.054e-06    1.24676e-06     20000   
+cprDe_highP:cprDeHighPTCFilter:TimeClusterFilter                                      6.241e-06    8.23416e-06   9.2528e-05     7.235e-06    3.06475e-06     20000   
+cprDe_highP_stopTarg:cprDeHighPStopTargPS:PrescaleEvent                               1.643e-06    2.25535e-06   9.9581e-05     1.984e-06    1.35877e-06     20000   
+cprDe_highP_stopTarg:cprDeHighPStopTargTCFilter:TimeClusterFilter                     6.504e-06    8.5756e-06    0.000317366    7.645e-06    3.93616e-06     20000   
+tprHelixUe:tprHelixUePS:PrescaleEvent                                                 1.803e-06    2.69534e-06   0.00178347     2.205e-06    1.27992e-05     20000   
+tprHelixUe:TTtimeClusterFinderUe:TimeClusterFinder                                   2.9036e-05    0.00147713     0.022752     0.000886164   0.00184305      20000   
+tprHelixUe:tprHelixUeTCFilter:TimeClusterFilter                                       7.886e-06    1.41909e-05   0.000944245   1.2954e-05    8.71736e-06     20000   
+tprHelixUe:TThelixFinderUe:RobustHelixFinder                                          9.829e-06    0.000308846    0.0215176    0.000131165   0.000557807     19786   
+tprHelixUe:TTHelixMergerUe:MergeHelices                                               9.938e-06    1.70914e-05   0.00036096    1.4627e-05    8.11711e-06     19786   
+tprHelixUe:tprHelixUeHSFilter:HelixFilter                                             5.801e-06    9.50877e-06   0.000376509    8.015e-06    5.03198e-06     19786   
+tprHelixDe:tprHelixDePS:PrescaleEvent                                                 1.894e-06    3.6297e-06    0.00087846     3.306e-06    6.4925e-06      20000   
+tprHelixDe:TTtimeClusterFinder:TimeClusterFinder                                     2.6451e-05    0.00139369     0.0227553    0.000821985   0.00177711      20000   
+tprHelixDe:tprHelixDeTCFilter:TimeClusterFilter                                       7.364e-06    1.40655e-05   0.00068513    1.3025e-05    7.8032e-06      20000   
+tprHelixDe:TThelixFinder:RobustHelixFinder                                            8.137e-06    0.000329013    0.0138463    0.000139055   0.000581284     19813   
+tprHelixDe:TTHelixMergerDe:MergeHelices                                               8.977e-06    1.65015e-05   0.000960977   1.4068e-05    1.11215e-05     19813   
+tprHelixDe:tprHelixDeHSFilter:HelixFilter                                              5.3e-06     9.09508e-06   0.000920249    7.804e-06    7.75739e-06     19813   
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledPS:PrescaleEvent                       2.034e-06    3.72934e-06   0.000328609    3.347e-06    3.13235e-06     20000   
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTCFilter:TimeClusterFilter             6.903e-06    1.18096e-05   0.000207577   1.0972e-05    4.47009e-06     20000   
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledHSFilter:HelixFilter                   4.99e-06     7.33387e-06   0.000196847    6.382e-06    3.42557e-06     19813   
+tprHelixDe_ipa:tprHelixDeIpaPS:PrescaleEvent                                          1.703e-06    2.58979e-06   0.00019868     2.314e-06    1.98795e-06     20000   
+tprHelixDe_ipa:tprHelixDeIpaTCFilter:TimeClusterFilter                                6.352e-06    9.50207e-06   0.000197999    8.606e-06    3.88548e-06     20000   
+tprHelixDe_ipa:tprHelixDeIpaHSFilter:HelixFilter                                      4.63e-06     6.47862e-06   0.00015642     5.612e-06    2.67507e-06     19813   
+tprDe_lowP_stopTarg:tprDeLowPStopTargPS:PrescaleEvent                                 1.703e-06    2.51712e-06   5.0396e-05     2.174e-06    1.3088e-06      20000   
+tprDe_lowP_stopTarg:tprDeLowPStopTargTCFilter:TimeClusterFilter                       6.542e-06    9.31403e-06   0.000270317    8.326e-06    4.47023e-06     20000   
+tprDe_lowP_stopTarg:tprDeLowPStopTargHSFilter:HelixFilter                             4.839e-06    7.27247e-06   9.5262e-05     6.402e-06    3.09571e-06     19904   
+tprDe_highP:tprDeHighPPS:PrescaleEvent                                                1.633e-06    2.49873e-06   0.000378403    2.084e-06    2.95895e-06     20000   
+tprDe_highP:tprDeHighPTCFilter:TimeClusterFilter                                      6.392e-06    9.27193e-06   0.000342785    7.966e-06    6.07192e-06     20000   
+tprDe_highP:tprDeHighPHSFilter:HelixFilter                                            4.718e-06    7.25093e-06   0.000349297    6.112e-06    4.68206e-06     19813   
+tprDe_highP_stopTarg:tprDeHighPStopTargPS:PrescaleEvent                               1.665e-06    2.39685e-06   4.7511e-05     2.053e-06    1.31011e-06     20000   
+tprDe_highP_stopTarg:tprDeHighPStopTargTCFilter:TimeClusterFilter                     6.512e-06    9.28085e-06   0.000294422    8.166e-06    4.94624e-06     20000   
+tprDe_highP_stopTarg:tprDeHighPStopTargHSFilter:HelixFilter                           4.749e-06    7.00253e-06   0.000282401    6.121e-06    3.87618e-06     19813   
+mprDe_highP_stopTarg:mprDeHighPStopTargPS:PrescaleEvent                               1.633e-06    2.37995e-06    4.213e-05     2.054e-06    1.28491e-06     20000   
+mprDe_highP_stopTarg:mprDeHighPStopTargTCFilter:TimeClusterFilter                     6.502e-06    1.00449e-05   0.000613233    8.196e-06    1.5407e-05      20000   
+mprDe_highP_stopTarg:TTRobustMultiHelixFinder:RobustMultiHelixFinder                  1.608e-05    0.00332808     0.177505     0.00111374    0.00754574      19813   
+mprDe_highP_stopTarg:TTMprHelixMergerDe:MergeHelices                                 1.2293e-05    0.000170343   0.00717142     4.726e-05    0.00036779      19813   
+mprDe_highP_stopTarg:mprDeHighPStopTargHSFilter:HelixFilter                           5.271e-06    2.24477e-05   0.000927002   1.7634e-05    2.01207e-05     19813   
+mprDe_highP_stopTarg:TTMprKSFDe:LoopHelixFit                                         0.000126622    0.0101608     0.0735379    0.00722089    0.00943599      12188   
+mprDe_highP_stopTarg:mprDeHighPStopTargKSFilter:KalSeedFilter                         8.085e-06    2.27737e-05   0.000984923   1.9187e-05    1.87687e-05     12188   
+[art]:TriggerResults:TriggerResultInserter                                            3.496e-06    5.10619e-06   0.000346552    4.318e-06    3.64403e-06     20000   
+cprHelixUe:TTCalHelixFinderUe:CalHelixFinder                                         6.1788e-05    0.000245039   0.00311805    0.000177129   0.00021029      1456    
+cprHelixUe:TTCalHelixMergerUe:MergeHelices                                            1.06e-05      1.573e-05    4.5366e-05    1.46685e-05   3.92462e-06     1456    
+cprHelixUe:cprHelixUeHSFilter:HelixFilter                                             5.871e-06    9.24121e-06   2.6651e-05    8.4665e-06    2.64489e-06     1456    
+cprHelixDe:TTCalHelixFinderDe:CalHelixFinder                                         4.2391e-05    0.000230109   0.00265145    0.000164655   0.000208042     1579    
+cprHelixDe:TTCalHelixMergerDe:MergeHelices                                            9.95e-06     1.56491e-05   0.000222365   1.3957e-05    8.02873e-06     1579    
+cprHelixDe:cprHelixDeHSFilter:HelixFilter                                             5.901e-06    9.41268e-06    3.132e-05     8.537e-06    3.00216e-06     1579    
+cprDe_lowP_stopTarg:cprDeLowPStopTargHSFilter:HelixFilter                             5.461e-06    8.98676e-06   0.000972249    7.715e-06    2.43982e-05     1579    
+cprDe_highP:cprDeHighPHSFilter:HelixFilter                                            5.019e-06    8.32631e-06   3.7913e-05     7.494e-06    3.06012e-06     1579    
+cprDe_highP_stopTarg:cprDeHighPStopTargHSFilter:HelixFilter                           5.181e-06    8.15444e-06   3.9526e-05     7.505e-06    2.84936e-06     1579    
+tprHelixDe:tprHelixDeTriggerInfoMerger:MergeTriggerInfo                              1.4128e-05    2.45294e-05   0.000249406   2.0529e-05    1.13966e-05     1413    
+tprDe_lowP_stopTarg:TTKSFDe:LoopHelixFit                                             0.00015138    0.00178177     0.0152907    0.00148445    0.00125063      1729    
+tprDe_lowP_stopTarg:tprDeLowPStopTargKSFilter:KalSeedFilter                           8.056e-06    1.63856e-05   0.000203599   1.5509e-05    7.16595e-06     1729    
+tprDe_lowP_stopTarg:tprDeLowPStopTargTriggerInfoMerger:MergeTriggerInfo              1.8053e-05    2.35809e-05   0.000245149    2.086e-05    1.78333e-05      167    
+aprHelix:aprHelixTriggerInfoMerger:MergeTriggerInfo                                  1.6843e-05    3.28927e-05   0.000365719    2.913e-05    2.75004e-05      306    
+apr_ue_highP:TTAprUeKSF:LoopHelixFit                                                 0.000148574   0.000692947   0.00298679    0.000493684   0.000573732      234    
+apr_ue_highP:aprUeHighPKSFilter:KalSeedFilter                                         7.875e-06    1.31516e-05   3.1691e-05    1.2159e-05    3.80424e-06      234    
+apr_highP:TTAprKSF:LoopHelixFit                                                      0.000148885   0.000711504   0.00288831    0.000525429   0.000552793      92     
+apr_highP:aprHighPKSFilter:KalSeedFilter                                              4.809e-06    9.28112e-06   2.5739e-05     8.681e-06    3.33474e-06      234    
+tprHelixUe:tprHelixUeTriggerInfoMerger:MergeTriggerInfo                              1.6091e-05    3.03432e-05   0.000363855   2.7843e-05    1.63507e-05     1884    
+tprDe_highP:tprDeHighPKSFilter:KalSeedFilter                                          4.829e-06    9.49801e-06   4.1179e-05     9.097e-06    3.79175e-06     1089    
+tprDe_highP_stopTarg:tprDeHighPStopTargKSFilter:KalSeedFilter                         4.739e-06    8.46962e-06   2.8654e-05     7.965e-06    3.30924e-06      695    
+mprDe_highP_stopTarg:mprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo            1.7924e-05    3.50975e-05   0.000126853   3.0468e-05    1.78063e-05      265    
+tprHelixDe_ipa:tprHelixDeIpaTriggerInfoMerger:MergeTriggerInfo                       1.1112e-05    1.81062e-05   8.5634e-05    1.6131e-05    7.02834e-06      543    
+tprDe_lowP_stopTarg:TThelixFinder:RobustHelixFinder                                   9.437e-06    4.32339e-05   0.000381759   1.6031e-05    7.33633e-05      91     
+tprDe_lowP_stopTarg:TTHelixMergerDe:MergeHelices                                      1.097e-05    1.40149e-05    3.108e-05    1.3215e-05    2.97184e-06      91     
+cprHelixDe:cprHelixDeTriggerInfoMerger:MergeTriggerInfo                               1.62e-05     4.55093e-05   0.00116179    2.8344e-05    0.00013211       73     
+cprDe_highP:TTCalSeedFitDe:LoopHelixFit                                              0.000189873   0.000966469   0.00270905    0.00071641    0.000886008       6     
+cprDe_highP:cprDeHighPKSFilter:KalSeedFilter                                          6.072e-06    1.01491e-05    3.153e-05     8.847e-06    4.7726e-06       39     
+tprDe_highP:TTKSFDe:LoopHelixFit                                                     0.000160286   0.00144734    0.00490701    0.00112932    0.000986053      121    
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTriggerInfoMerger:MergeTriggerInfo    1.1833e-05    2.11223e-05   0.000111203   1.7454e-05    1.23972e-05      139    
+apr_lowP_stopTarg:TTAprKSF:LoopHelixFit                                              0.000163242   0.000814506   0.00299661    0.000646882   0.000606682      204    
+apr_lowP_stopTarg:aprLowPStopTargKSFilter:KalSeedFilter                               6.061e-06    1.39276e-05   2.9616e-05    1.27195e-05   4.12236e-06      212    
+cprDe_lowP_stopTarg:TTCalSeedFitDe:LoopHelixFit                                      0.000147511   0.000912937   0.00359204    0.00108561    0.000636924      69     
+cprDe_lowP_stopTarg:cprDeLowPStopTargKSFilter:KalSeedFilter                             1e-05      1.51081e-05    4.142e-05    1.4838e-05    4.40775e-06      69     
+apr_highP_stopTarg:aprHighPStopTargKSFilter:KalSeedFilter                             5.43e-06     8.59706e-06   5.6428e-05     6.953e-06    6.56812e-06      69     
+cprDe_lowP_stopTarg:cprDeLowPStopTargTriggerInfoMerger:MergeTriggerInfo              1.8515e-05    2.17232e-05   4.3975e-05    1.9326e-05    5.97813e-06      18     
+apr_lowP_multiHelix:TTAprKSF:LoopHelixFit                                            0.000601741   0.00143533    0.00261491    0.00115511    0.000619882       9     
+apr_lowP_multiHelix:aprLowPMultiHelixKSFilter:KalSeedFilter                          1.1683e-05    1.42683e-05   1.6622e-05    1.3886e-05    1.76625e-06       9     
+apr_lowP_stopTarg:aprLowPStopTargTriggerInfoMerger:MergeTriggerInfo                  1.7764e-05    2.10598e-05   2.9927e-05    2.0314e-05    2.46268e-06      24     
+apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkKSFilter:KalSeedFilter            6.303e-06    9.54625e-06   1.1423e-05    1.02295e-05   1.93705e-06       4     
+cprDe_highP_stopTarg:cprDeHighPStopTargKSFilter:KalSeedFilter                         5.731e-06    9.11178e-06   1.2433e-05     8.952e-06    1.78441e-06      18     
+tprDe_highP:tprDeHighPTriggerInfoMerger:MergeTriggerInfo                             1.9828e-05    2.11682e-05   2.3496e-05    2.06745e-05   1.45881e-06       4     
+cprDe_highP:cprDeHighPTriggerInfoMerger:MergeTriggerInfo                             3.1189e-05    3.1189e-05    3.1189e-05    3.1189e-05         0            1     
+cprDe_highP_stopTarg:cprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo             1.559e-05     1.559e-05     1.559e-05     1.559e-05         0            1     
+apr_highP:aprHighPTriggerInfoMerger:MergeTriggerInfo                                 2.2072e-05    2.2072e-05    2.2072e-05    2.2072e-05         0            1     
 =======================================================================================================================================================================
 DbEngine::endJob
-    Total time in reading DB: 0.584494 s
+    Total time in reading DB: 0.638625 s
     Total time waiting for locks: 1e-06 s
-    Total time in locks: 0.447739 s
+    Total time in locks: 0.476474 s
     valcache memory: 58065 b
   Database cache stats:
     cache nTable : 11
@@ -239,6 +245,7 @@ TrigReport        170      20000         73      19927          0 cprHelixDe
 TrigReport        171      20000         28      19972          0 cprHelixUe
 TrigReport        180      20000          0      20000          0 apr_highP_stopTarg
 TrigReport        181      20000          1      19999          0 apr_highP
+TrigReport        185      20000          0      20000          0 apr_ue_highP
 TrigReport        190      20000         24      19976          0 apr_lowP_stopTarg
 TrigReport        191      20000          0      20000          0 apr_highP_stopTarg_multiTrk
 TrigReport        192      20000          0      20000          0 apr_lowP_multiHelix
@@ -362,6 +369,24 @@ TrigReport        190      15995        212      15783          0 aprLowPStopTar
 TrigReport        190        212        212          0          0 TTAprKSF
 TrigReport        190        212         24        188          0 aprLowPStopTargKSFilter
 TrigReport        190         24         24          0          0 aprLowPStopTargTriggerInfoMerger
+
+TrigReport ---------- Modules in path: apr_ue_highP ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        185      20000      20000          0          0 processDTCAndCFOEvents
+TrigReport        185      20000      20000          0          0 aprUeHighPPS
+TrigReport        185      20000      20000          0          0 CaloHitMakerFast
+TrigReport        185      20000      20000          0          0 CaloClusterFast
+TrigReport        185      20000      20000          0          0 TTmakeSH
+TrigReport        185      20000      20000          0          0 TTmakePH
+TrigReport        185      20000      20000          0          0 TTflagPH
+TrigReport        185      20000      20000          0          0 TTTZClusterFinder
+TrigReport        185      20000      15995       4005          0 aprUeHighPTCFilter
+TrigReport        185      15995      15995          0          0 TTAprHelixFinder
+TrigReport        185      15995      15995          0          0 TTAprHelixMerger
+TrigReport        185      15995        234      15761          0 aprUeHighPHSFilter
+TrigReport        185        234        234          0          0 TTAprUeKSF
+TrigReport        185        234          0        234          0 aprUeHighPKSFilter
+TrigReport        185          0          0          0          0 aprUeHighPTriggerInfoMerger
 
 TrigReport ---------- Modules in path: caloFast_MVANNCE ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -661,13 +686,14 @@ TrigReport        131       1884       1884          0          0 tprHelixUeTrig
 
 TrigReport ---------- Module summary ------------
 TrigReport    Visited        Run     Passed     Failed      Error Name
-TrigReport     460000      20000      20000          0          0 CaloClusterFast
-TrigReport     460000      20000      20000          0          0 CaloHitMakerFast
+TrigReport     480000      20000      20000          0          0 CaloClusterFast
+TrigReport     480000      20000      20000          0          0 CaloHitMakerFast
 TrigReport          0          0          0          0          0 CstLineFinder
 TrigReport          0          0          0          0          0 CstSimpleTimeCluster
-TrigReport      95970      15995      15995          0          0 TTAprHelixFinder
-TrigReport      95970      15995      15995          0          0 TTAprHelixMerger
+TrigReport     111965      15995      15995          0          0 TTAprHelixFinder
+TrigReport     111965      15995      15995          0          0 TTAprHelixMerger
 TrigReport        528        305        305          0          0 TTAprKSF
+TrigReport        234        234        234          0          0 TTAprUeKSF
 TrigReport       6316       1579       1579          0          0 TTCalHelixFinderDe
 TrigReport       1456       1456       1456          0          0 TTCalHelixFinderUe
 TrigReport       6316       1579       1579          0          0 TTCalHelixMergerDe
@@ -683,12 +709,12 @@ TrigReport      12188      12188      12188          0          0 TTMprKSFDe
 TrigReport          0          0          0          0          0 TTOmakePH
 TrigReport          0          0          0          0          0 TTOmakeSH
 TrigReport      19813      19813      19813          0          0 TTRobustMultiHelixFinder
-TrigReport     120000      20000      20000          0          0 TTTZClusterFinder
-TrigReport     380000      20000      20000          0          0 TTflagPH
+TrigReport     140000      20000      20000          0          0 TTTZClusterFinder
+TrigReport     400000      20000      20000          0          0 TTflagPH
 TrigReport     118969      19904      19904          0          0 TThelixFinder
 TrigReport      19786      19786      19786          0          0 TThelixFinderUe
-TrigReport     380000      20000      20000          0          0 TTmakePH
-TrigReport     380000      20000      20000          0          0 TTmakeSH
+TrigReport     400000      20000      20000          0          0 TTmakePH
+TrigReport     400000      20000      20000          0          0 TTmakeSH
 TrigReport     140000      20000      20000          0          0 TTtimeClusterFinder
 TrigReport      20000      20000      20000          0          0 TTtimeClusterFinderUe
 TrigReport      15995      15995        306      15689          0 aprHelixHSFilter
@@ -719,6 +745,11 @@ TrigReport        212        212         24        188          0 aprLowPStopTar
 TrigReport      40000      20000      20000          0          0 aprLowPStopTargPS
 TrigReport      20000      20000      15995       4005          0 aprLowPStopTargTCFilter
 TrigReport         24         24         24          0          0 aprLowPStopTargTriggerInfoMerger
+TrigReport      15995      15995        234      15761          0 aprUeHighPHSFilter
+TrigReport        234        234          0        234          0 aprUeHighPKSFilter
+TrigReport      20000      20000      20000          0          0 aprUeHighPPS
+TrigReport      20000      20000      15995       4005          0 aprUeHighPTCFilter
+TrigReport          0          0          0          0          0 aprUeHighPTriggerInfoMerger
 TrigReport      20000      20000          0      20000          0 caloFastCosmicFilter
 TrigReport      20000      20000      20000          0          0 caloFastCosmicPS
 TrigReport      20000      20000       1844      18156          0 caloFastMVANNCEFilter
@@ -769,7 +800,7 @@ TrigReport      12188      12188        265      11923          0 mprDeHighPStop
 TrigReport      20000      20000      20000          0          0 mprDeHighPStopTargPS
 TrigReport      20000      20000      19813        187          0 mprDeHighPStopTargTCFilter
 TrigReport        265        265        265          0          0 mprDeHighPStopTargTriggerInfoMerger
-TrigReport     560000      20000      20000          0          0 processDTCAndCFOEvents
+TrigReport     580000      20000      20000          0          0 processDTCAndCFOEvents
 TrigReport      19813      19813       1089      18724          0 tprDeHighPHSFilter
 TrigReport       1089       1089          4       1085          0 tprDeHighPKSFilter
 TrigReport      20000      20000      20000          0          0 tprDeHighPPS
@@ -803,9 +834,9 @@ TrigReport      20000      20000      19786        214          0 tprHelixUeTCFi
 TrigReport       1884       1884       1884          0          0 tprHelixUeTriggerInfoMerger
 
 TimeReport ---------- Time summary [sec] -------
-TimeReport CPU = 384.753305 Real = 439.643823
+TimeReport CPU = 354.229421 Real = 383.701960
 
 MemReport  ---------- Memory summary [base-10 MB] ------
-MemReport  VmPeak = 1526.87 VmHWM = 578.671
+MemReport  VmPeak = 1526.56 VmHWM = 580.37
 
 Art has completed and will exit with status 0.

--- a/core/filters/trigAprFilters.fcl
+++ b/core/filters/trigAprFilters.fcl
@@ -11,6 +11,8 @@ TrigAprFilters:{
       eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
    aprLowPMultiHelixPS: { module_type: PrescaleEvent
       eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
+  aprUeHighPPS             : { module_type: PrescaleEvent
+      eventModeConfig : [  { eventMode: OnSpill prescale:-1}, { eventMode: OffSpill prescale:-1} ]}
 
   aprHighPStopTargHSFilter: {
     module_type: "HelixFilter"
@@ -166,6 +168,92 @@ TrigAprFilters:{
       },
       {#cuts for downstreeam e-plus
         fitdirection: @local::FitDir.downstream
+        fitparticle: @local::Particle.eplus
+        maxChi2DOF: 20
+        maxD0: 600
+        maxMomErr: 10
+        maxMomentum: 2000
+        maxTanDip: 1000
+        minD0: -600
+        minFitCons: -1
+        minMomentum: 70
+        minNStrawHits: 15
+        minTanDip: 0
+        requireCaloCluster: false
+      }
+    ]
+  }
+
+  #upstream track trigger filters
+  aprUeHighPHSFilter: {
+    module_type: "HelixFilter"
+    helixSeedCollection: "TTAprHelixMerger"
+    posHelicitySelection : {
+      configured: true
+      doHelicityCheck: true
+      maxAbsLambda: 1000
+      maxChi2PhiZ: 8
+      maxChi2XY: 8
+      maxD0: 600
+      maxMomentum: 2000
+      maxNLoops: 30
+      minAbsLambda: 50
+      minD0: -600
+      minHitRatio: 4e-1
+      minMomentum: 80
+      minNLoops: 0
+      minNStrawHits: 15
+      minPt: 0
+      prescaleUsingD0Phi: false
+      requireCaloCluster: false
+    }
+    negHelicitySelection: {
+      configured: true
+      doHelicityCheck: true
+      maxAbsLambda: 1000
+      maxChi2PhiZ: 8
+      maxChi2XY: 8
+      maxD0: 600
+      maxMomentum: 2000
+      maxNLoops: 30
+      minAbsLambda: 50
+      minD0: -600
+      minHitRatio: 4e-1
+      minMomentum: 70
+      minNLoops: 0
+      minNStrawHits: 15
+      minPt: 0
+      prescaleUsingD0Phi: false
+      requireCaloCluster: false
+    }
+  }
+  aprUeHighPTCFilter : {
+    minNStrawHits: 15
+    module_type: "TimeClusterFilter"
+    requireCaloCluster: false
+    timeClusterCollection: "TTTZClusterFinder"
+  }
+  aprUeHighPKSFilter: {
+    kalSeedCollections: [ "TTAprUeKSF" ]
+    module_type: "KalSeedFilter"
+    KalSeedCuts : [
+      { #cuts for upstream e-minus
+        fitdirection: @local::FitDir.upstream
+        fitparticle: @local::Particle.eminus
+        maxChi2DOF: 20
+        maxD0: 600
+        maxMomErr: 10
+        maxMomentum: 2000
+        maxTanDip: 1000
+        minD0: -600
+        minFitCons: -1
+        minMomentum: 80
+        minNStrawHits: 15
+        minTanDip: 0
+        requireCaloCluster: false
+      },
+      {#cuts for upstream e-plus
+        fitdirection: @local::FitDir.upstream
         fitparticle: @local::Particle.eplus
         maxChi2DOF: 20
         maxD0: 600

--- a/core/producers/trigAprProducers.fcl
+++ b/core/producers/trigAprProducers.fcl
@@ -45,6 +45,22 @@ TrigAprProducers : {
     PrioritizeCaloHits : true
   }
 
+  TTAprUeKSF: {
+    module_type : LoopHelixFit
+    MaterialSettings : { @table::Mu2eKinKalTrigger.MAT     }
+    KKFitSettings    : { @table::Mu2eKinKalTrigger.KKFIT   }
+    FitSettings      : { @table::Mu2eKinKalTrigger.SEEDFIT }
+    ExtensionSettings: { @table::Mu2eKinKalTrigger.SEEDEXT }
+    ModuleSettings   : {
+      @table::Mu2eKinKalTrigger.LOOPHELIX
+      FitParticle : @local::Particle.eminus
+      HelixSeedCollections   : [ "TTAprHelixMerger" ]
+    }
+    UsePDGCharge     : false
+    FitDirection     : @local::FitDir.upstream
+    PrioritizeCaloHits : true
+  }
+
   aprHighPStopTargTriggerInfoMerger: {
     module_type: "MergeTriggerInfo"
   }
@@ -58,6 +74,9 @@ TrigAprProducers : {
     module_type: "MergeTriggerInfo"
   }
   aprLowPMultiHelixTriggerInfoMerger: {
+    module_type: "MergeTriggerInfo"
+  }
+  aprUeHighPTriggerInfoMerger: {
     module_type: "MergeTriggerInfo"
   }
   aprHelixTriggerInfoMerger: {

--- a/core/trigSequences.fcl
+++ b/core/trigSequences.fcl
@@ -212,7 +212,14 @@ TrigTrkPaths:{
       @sequence::TrigRecoSequences.trkPrepareHits,
       TTTZClusterFinder ]
 
-   aprHelix          : [ @sequence::TrigRecoSequences.dtcAndCFOEventsGen,
+  apr_ue_highP                     : [ @sequence::TrigRecoSequences.dtcAndCFOEventsGen,
+      aprUeHighPPS, @sequence::TrigRecoSequences.calReco,
+      @sequence::TrigRecoSequences.trkPrepareHits,
+      TTTZClusterFinder, aprUeHighPTCFilter,
+      TTAprHelixFinder, TTAprHelixMerger, aprUeHighPHSFilter,
+      TTAprUeKSF, aprUeHighPKSFilter, aprUeHighPTriggerInfoMerger ]
+
+  aprHelix          : [ @sequence::TrigRecoSequences.dtcAndCFOEventsGen,
       aprLowPStopTargPS, @sequence::TrigRecoSequences.calReco,
       @sequence::TrigRecoSequences.trkPrepareHits,
       TTTZClusterFinder, aprHelixTCFilter, TTAprHelixFinder, TTAprHelixMerger,

--- a/data/physMenu.json
+++ b/data/physMenu.json
@@ -118,6 +118,14 @@
                                ]
         },
 
+        "apr_ue_highP"   : {
+            "bit" : 185,
+            "enabled": 1,
+            "eventModeConfig": [{"eventMode":"OnSpill", "prescale":1, "streams": [ "physics_main", "dqm_trigger" ] },
+                                {"eventMode":"OffSpill", "prescale":1, "streams": [ "cosmics_main", "physics_trk_calib" ]          }
+                               ]
+        },
+
         "apr_lowP_stopTarg"   : {
             "bit" : 190 ,
             "enabled": 1,


### PR DESCRIPTION
Add an APR upstream track trigger with bit `185`. This could be useful for studying the downstream trigger efficiencies using cosmic rebound events that are triggered on the upstream leg. I've only added the APR path for now as the helix finding stage is agnostic to the helix trajectory, but the CPR version would require a second helix finder instance.

Adding this path will double the APR track reconstruction time due to the two instances, but this time is negligible compared to the helix finding stage due to the high background rejection at this stage. We can further improve the timing by adding cuts on the helix slope in the track fitting instances, but I've left this out for now to avoid filtering/potential systematic uncertainties if they're not needed.