### PR TITLE
removing the now unnecessary combo hit collection in TZClusterFinder

### DIFF
--- a/core/producers/trigAprProducers.fcl
+++ b/core/producers/trigAprProducers.fcl
@@ -3,7 +3,6 @@ BEGIN_PROLOG
 TrigAprProducers : {
   TTTZClusterFinder : { @table::CalPatRec.producers.TZClusterFinder
     chCollLabel                : "TTflagPH"
-    chCollLabel2               : "TTmakeSH"
     ccCollLabel                : "CaloClusterFast"
   }
 


### PR DESCRIPTION
See PR #1491 in Offline. 