### PR TITLE
Updates to APR Helix selection and addition of helix mask to APR and CPR track fitters

### DIFF
--- a/ci/reference_log_file.log
+++ b/ci/reference_log_file.log
@@ -1,13 +1,13 @@
    ************************** Mu2e Offline **************************
      art v3_15_00    root v6_32_06    KinKal v03_02_01
-     build  /exp/mu2e/app/users/nmazotov/Official
-     build  al9-prof-e29-p079    07/09/25 15:50:55
+     build  /exp/mu2e/app/users/izarif/Single_Electron
+     build  al9-prof-e29-p083    07/24/25 16:21:01
    ******************************************************************
-Conditions file: /exp/mu2e/app/users/nmazotov/Official/Offline/ConditionsService/data/conditions_01.txt
+Conditions file: /exp/mu2e/app/users/izarif/Single_Electron/Offline/ConditionsService/data/conditions_01.txt
 Conditions lines: 38  hash: 8098310628555253397
 DbService  MDC2020_best v1_3   mu2e_conditions_prd
 DbService  textFiles: 
-GlobalConstants file: /exp/mu2e/app/users/nmazotov/Official/Offline/GlobalConstantsService/data/globalConstants_01.txt
+GlobalConstants file: /exp/mu2e/app/users/izarif/Single_Electron/Offline/GlobalConstantsService/data/globalConstants_01.txt
 GlobalConstants lines: 165  hash: 10185786924093877558
 BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing ( 0x1 : Inactive )
 BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing ( 0x1 : Inactive )
@@ -15,16 +15,16 @@ BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing (
 BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing ( 0x1 : Inactive )
 BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing ( 0x1 : Inactive )
 DeltaFinderAlg created
-09-Jul-2025 16:47:56 CDT  Initiating request to open input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
-09-Jul-2025 16:47:57 CDT  Opened input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
+24-Jul-2025 16:40:11 CDT  Initiating request to open input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
+24-Jul-2025 16:40:11 CDT  Opened input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
 tprHelixDeIpaHSFilter NO HELIX CUT HAS BEEN SET FOR THE HELICES WITH NEGATIVE HELICITY. IF THAT'S NOT THE DESIRED BEHAVIOUR REVIEW YOUR CONFIGUREATION!
 tprHelixDeIpaPhiScaledHSFilter NO HELIX CUT HAS BEEN SET FOR THE HELICES WITH NEGATIVE HELICITY. IF THAT'S NOT THE DESIRED BEHAVIOUR REVIEW YOUR CONFIGUREATION!
-Geometry file: /exp/mu2e/app/users/nmazotov/Official/Offline/Mu2eG4/geom/geom_common.txt
-Geometry lines: 21867  hash: 13997749539754636457
-BField file: /exp/mu2e/app/users/nmazotov/Official/Offline/Mu2eG4/geom/bfgeom_reco_v01.txt
+Geometry file: /exp/mu2e/app/users/izarif/Single_Electron/Offline/Mu2eG4/geom/geom_common.txt
+Geometry lines: 21724  hash: 5962533537671616341
+BField file: /exp/mu2e/app/users/izarif/Single_Electron/Offline/Mu2eG4/geom/bfgeom_reco_v01.txt
 BField lines: 98  hash: 3243269116804334601
-Begin processing the 1st record. run: 1202 subRun: 0 event: 1 at 09-Jul-2025 16:48:14 CDT
-DbReader::fillValCache took 0.308056 s
+Begin processing the 1st record. run: 1202 subRun: 0 event: 1 at 24-Jul-2025 16:40:29 CDT
+DbReader::fillValCache took 0.25805 s
 DbEngine confirmed purpose and version:
 MDC2020_best 1/3/-1
 DbEngine IoV summary
@@ -49,181 +49,181 @@ DbEngine IoV summary
              CRVSiPM       3
            CRVPhoton       3
              CRVTime       3
-DbEngine inclusive beginJob time was 0.308277 s
-Begin processing the 2nd record. run: 1202 subRun: 0 event: 2 at 09-Jul-2025 16:48:15 CDT
-Begin processing the 3rd record. run: 1202 subRun: 0 event: 3 at 09-Jul-2025 16:48:15 CDT
-Begin processing the 5th record. run: 1202 subRun: 0 event: 5 at 09-Jul-2025 16:48:15 CDT
-Begin processing the 9th record. run: 1202 subRun: 0 event: 9 at 09-Jul-2025 16:48:16 CDT
-Begin processing the 17th record. run: 1202 subRun: 0 event: 17 at 09-Jul-2025 16:48:16 CDT
-Begin processing the 33rd record. run: 1202 subRun: 0 event: 33 at 09-Jul-2025 16:48:16 CDT
-Begin processing the 65th record. run: 1202 subRun: 0 event: 65 at 09-Jul-2025 16:48:17 CDT
-Begin processing the 129th record. run: 1202 subRun: 0 event: 129 at 09-Jul-2025 16:48:18 CDT
-Begin processing the 257th record. run: 1202 subRun: 0 event: 257 at 09-Jul-2025 16:48:21 CDT
-Begin processing the 513th record. run: 1202 subRun: 0 event: 513 at 09-Jul-2025 16:48:29 CDT
-Begin processing the 1025th record. run: 1202 subRun: 0 event: 1025 at 09-Jul-2025 16:48:42 CDT
-Begin processing the 2049th record. run: 1202 subRun: 0 event: 2049 at 09-Jul-2025 16:49:08 CDT
-Begin processing the 4097th record. run: 1202 subRun: 1 event: 97 at 09-Jul-2025 16:50:00 CDT
-Begin processing the 8193rd record. run: 1202 subRun: 2 event: 193 at 09-Jul-2025 16:51:33 CDT
-09-Jul-2025 16:52:10 CDT  Closed input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
-09-Jul-2025 16:52:10 CDT  Initiating request to open input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
-09-Jul-2025 16:52:10 CDT  Opened input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
-%MSG-w GEOM:  BeginRun 09-Jul-2025 16:52:10 CDT run: 1202
+DbEngine inclusive beginJob time was 0.258288 s
+Begin processing the 2nd record. run: 1202 subRun: 0 event: 2 at 24-Jul-2025 16:40:29 CDT
+Begin processing the 3rd record. run: 1202 subRun: 0 event: 3 at 24-Jul-2025 16:40:29 CDT
+Begin processing the 5th record. run: 1202 subRun: 0 event: 5 at 24-Jul-2025 16:40:29 CDT
+Begin processing the 9th record. run: 1202 subRun: 0 event: 9 at 24-Jul-2025 16:40:30 CDT
+Begin processing the 17th record. run: 1202 subRun: 0 event: 17 at 24-Jul-2025 16:40:30 CDT
+Begin processing the 33rd record. run: 1202 subRun: 0 event: 33 at 24-Jul-2025 16:40:30 CDT
+Begin processing the 65th record. run: 1202 subRun: 0 event: 65 at 24-Jul-2025 16:40:31 CDT
+Begin processing the 129th record. run: 1202 subRun: 0 event: 129 at 24-Jul-2025 16:40:31 CDT
+Begin processing the 257th record. run: 1202 subRun: 0 event: 257 at 24-Jul-2025 16:40:34 CDT
+Begin processing the 513th record. run: 1202 subRun: 0 event: 513 at 24-Jul-2025 16:40:39 CDT
+Begin processing the 1025th record. run: 1202 subRun: 0 event: 1025 at 24-Jul-2025 16:40:49 CDT
+Begin processing the 2049th record. run: 1202 subRun: 0 event: 2049 at 24-Jul-2025 16:41:09 CDT
+Begin processing the 4097th record. run: 1202 subRun: 1 event: 97 at 24-Jul-2025 16:41:45 CDT
+Begin processing the 8193rd record. run: 1202 subRun: 2 event: 193 at 24-Jul-2025 16:43:05 CDT
+24-Jul-2025 16:43:40 CDT  Closed input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
+24-Jul-2025 16:43:40 CDT  Initiating request to open input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
+24-Jul-2025 16:43:40 CDT  Opened input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
+%MSG-w GEOM:  BeginRun 24-Jul-2025 16:43:40 CDT run: 1202
 This test version does not change geometry on run boundaries.
 %MSG
 This test version does not change geometry on run boundaries.
-Begin processing the 16385th record. run: 1202 subRun: 4 event: 385 at 09-Jul-2025 16:54:20 CDT
-09-Jul-2025 16:55:34 CDT  Closed input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
+Begin processing the 16385th record. run: 1202 subRun: 4 event: 385 at 24-Jul-2025 16:45:41 CDT
+24-Jul-2025 16:46:50 CDT  Closed input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
 
 =======================================================================================================================================================================
 TimeTracker printout (sec)                                                               Min           Avg           Max         Median          RMS         nEvts   
 =======================================================================================================================================================================
-Full event                                                                           0.00109358     0.0218467      1.29102      0.0121221     0.0296518      20000   
+Full event                                                                           0.00105854     0.018939      0.905757      0.0105863     0.0247999      20000   
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-source:RootInput(read)                                                               6.9643e-05    0.000356843    0.0497699    0.000112694   0.00255827      20000   
-caloHitRec_N0Source:processCFOData:EventHeaderFromCFOFragment                        1.1132e-05    1.85471e-05    0.0101405    1.4028e-05    0.00016161      20000   
-caloHitRec_N0Source:caloHitRecN0SourcePS:PrescaleEvent                                8.747e-06    5.32684e-05    0.0762626    1.2123e-05    0.00119153      20000   
-minBias_CDCount:minBiasCDCountPS:PrescaleEvent                                        1.894e-06    2.79438e-06   0.000171737    2.515e-06    2.24398e-06     20000   
-minBias_SDCount:minBiasSDCountPS:PrescaleEvent                                        1.514e-06    2.20842e-06   0.000206824    2.024e-06    1.86531e-06     20000   
-cstCosmicTrackSeed:cstCosmicTrackSeedPS:PrescaleEvent                                 1.553e-06    2.72301e-06    0.010023      1.984e-06    7.08805e-05     20000   
-cstTimeCluster:cstTimeClusterPS:PrescaleEvent                                         1.473e-06    2.57508e-06    0.0100193     1.874e-06    7.08525e-05     20000   
-caloFast_RMC:caloFastRMCPS:PrescaleEvent                                              1.523e-06    2.16309e-06   3.4806e-05     2.004e-06    1.0556e-06      20000   
-caloFast_RMC:CaloHitMakerFast:CaloHitMakerFast                                       7.6956e-05    0.000788301    0.0717455    0.000472068   0.00177384      20000   
-caloFast_RMC:CaloClusterFast:CaloClusterFast                                         1.0259e-05    6.87392e-05    0.0160829    5.5115e-05    0.000188586     20000   
-caloFast_RMC:caloFastRMCFilter:CaloClusterCounterFilter                               6.793e-06    9.64822e-06   0.00219199     8.766e-06    1.57467e-05     20000   
-caloFast_cosmic:caloFastCosmicPS:PrescaleEvent                                        2.595e-06    4.10023e-06   0.000213677    3.738e-06    2.99091e-06     20000   
-caloFast_cosmic:caloFastCosmicFilter:CaloCosmicCalib                                  4.579e-06    6.39677e-06   0.000215209    5.781e-06    3.16154e-06     20000   
-caloFast_MVANNCE:caloFastMVANNCEPS:PrescaleEvent                                      1.774e-06    2.47822e-06   0.000199961    2.244e-06    2.37814e-06     20000   
-caloFast_MVANNCE:caloFastMVANNCEFilter:FilterEcalNNTrigger                            5.22e-06     9.20215e-06    0.0101514     7.826e-06    7.78931e-05     20000   
-caloFast_photon:caloFastPhotonPS:PrescaleEvent                                        1.683e-06    2.4175e-06    6.0586e-05     2.194e-06    1.37126e-06     20000   
-caloFast_photon:caloFastPhotonFilter:CaloLikelihood                                   5.39e-06     9.13838e-06   0.00488982     6.963e-06    3.48459e-05     20000   
-aprHelix:aprLowPStopTargPS:PrescaleEvent                                              1.824e-06    2.82004e-06   0.000207806    2.525e-06    2.12556e-06     20000   
-aprHelix:TTmakeSD:StrawDigisFromArtdaqFragments                                       8.737e-06    1.34791e-05    0.0100458    1.0439e-05    0.000117655     20000   
-aprHelix:TTmakeSH:StrawHitReco                                                       3.9655e-05    0.000602153     1.22778     0.00041453    0.00871611      20000   
-aprHelix:TTmakePH:CombineStrawHits                                                    8.847e-06    8.22618e-05    0.0130648    6.2519e-05    0.000163311     20000   
-aprHelix:TTflagPH:DeltaFinder                                                        8.6786e-05    0.000512696    0.0165605    0.000375695   0.000580698     20000   
-aprHelix:TTTZClusterFinder:TZClusterFinder                                           1.2884e-05    0.000102448    0.0101449    7.0996e-05     0.0001879      20000   
-aprHelix:aprHelixTCFilter:TimeClusterFilter                                          1.0259e-05    1.48917e-05    0.010051     1.3115e-05    7.12071e-05     20000   
-aprHelix:TTAprHelixFinder:AgnosticHelixFinder                                        1.0471e-05    0.000293949    0.0176139    0.000104064   0.000603191     16392   
-aprHelix:TTAprHelixMerger:MergeHelices                                               1.1823e-05    1.67369e-05    0.0116152    1.3986e-05    0.000119875     16392   
-aprHelix:aprHelixHSFilter:HelixFilter                                                 6.032e-06    7.9792e-06    0.000220249    7.304e-06    3.46439e-06     16392   
-apr_lowP_multiHelix:aprLowPMultiHelixPS:PrescaleEvent                                 2.455e-06    3.74213e-06   0.000253624    3.466e-06    2.36169e-06     20000   
-apr_lowP_multiHelix:aprLowPMultiHelixTCFilter:TimeClusterFilter                       7.735e-06    1.13779e-05   0.00616819    1.0229e-05    4.38147e-05     20000   
-apr_lowP_multiHelix:aprLowPMultiHelixHSFilter:HelixFilter                             5.299e-06    7.78747e-06    0.0100848     6.522e-06    7.88196e-05     16392   
-apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkPS:PrescaleEvent                  1.783e-06    2.95855e-06   0.00602415     2.404e-06    4.26275e-05     20000   
-apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkTCFilter:TimeClusterFilter        7.304e-06    1.01904e-05   0.00995779     8.897e-06    7.04285e-05     20000   
-apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkHSFilter:HelixFilter              5.12e-06     6.73654e-06   0.00113148     6.051e-06    9.46238e-06     16392   
-apr_lowP_stopTarg:aprLowPStopTargTCFilter:TimeClusterFilter                           7.023e-06    9.15372e-06   0.000205942    8.376e-06    3.96739e-06     20000   
-apr_lowP_stopTarg:aprLowPStopTargHSFilter:HelixFilter                                 4.709e-06    6.51882e-06    0.0040282     5.732e-06    3.1676e-05      16392   
-apr_ue_highP:aprUeHighPPS:PrescaleEvent                                               1.713e-06    2.43694e-06   0.000250667    2.185e-06    2.89058e-06     20000   
-apr_ue_highP:aprUeHighPTCFilter:TimeClusterFilter                                     6.492e-06    9.08353e-06    0.008088      7.894e-06    5.73539e-05     20000   
-apr_ue_highP:aprUeHighPHSFilter:HelixFilter                                           4.82e-06     7.27998e-06    0.0100327     5.73e-06     9.25036e-05     16392   
-apr_highP:aprHighPPS:PrescaleEvent                                                    1.703e-06    2.45202e-06   0.000161487   2.2055e-06    1.92663e-06     20000   
-apr_highP:aprHighPTCFilter:TimeClusterFilter                                          6.432e-06    8.97773e-06    0.0100464     7.664e-06    7.1154e-05      20000   
-apr_highP:aprHighPHSFilter:HelixFilter                                                4.57e-06     6.67815e-06    0.0100395      5.5e-06     7.84132e-05     16392   
-apr_highP_stopTarg:aprHighPStopTargPS:PrescaleEvent                                   1.693e-06    2.76336e-06   0.00403794     2.204e-06    3.57056e-05     20000   
-apr_highP_stopTarg:aprHighPStopTargTCFilter:TimeClusterFilter                         6.542e-06    8.64257e-06   0.000216683    7.864e-06    3.92882e-06     20000   
-apr_highP_stopTarg:aprHighPStopTargHSFilter:HelixFilter                               4.689e-06    7.00191e-06    0.0100354     5.781e-06    7.86961e-05     16392   
-cprHelixUe:cprHelixUePS:PrescaleEvent                                                 1.723e-06    2.41796e-06   0.000190313    2.194e-06    1.86548e-06     20000   
-cprHelixUe:TTCalTimePeakFinderUe:CalTimePeakFinder                                    8.386e-06    1.38178e-05   0.00114749     1.069e-05    1.2037e-05      20000   
-cprHelixUe:cprHelixUeTCFilter:TimeClusterFilter                                       7.474e-06    9.56537e-06   0.000298278    8.706e-06    4.26321e-06     20000   
-cprHelixDe:cprHelixDePS:PrescaleEvent                                                 1.733e-06    2.80239e-06   0.00705721     2.214e-06    4.99121e-05     20000   
-cprHelixDe:TTCalTimePeakFinder:CalTimePeakFinder                                      6.983e-06    1.26748e-05    0.0100295     8.255e-06    0.000110186     20000   
-cprHelixDe:cprHelixDeTCFilter:TimeClusterFilter                                       6.904e-06    1.04449e-05    0.0160436     8.075e-06    0.000135493     20000   
-cprDe_lowP_stopTarg:cprDeLowPStopTargPS:PrescaleEvent                                 1.704e-06    2.53777e-06   0.000280825    2.255e-06    2.95348e-06     20000   
-cprDe_lowP_stopTarg:cprDeLowPStopTargTCFilter:TimeClusterFilter                       6.714e-06    9.11316e-06   0.00455814     7.975e-06    3.24423e-05     20000   
-cprDe_highP:cprDeHighPPS:PrescaleEvent                                                1.603e-06    2.79798e-06    0.0100174     2.094e-06    7.08287e-05     20000   
-cprDe_highP:cprDeHighPTCFilter:TimeClusterFilter                                      6.533e-06    8.2874e-06    0.00120981     7.475e-06    8.9874e-06      20000   
-cprDe_highP_stopTarg:cprDeHighPStopTargPS:PrescaleEvent                               1.614e-06    2.94854e-06    0.0146354     2.024e-06    0.000103477     20000   
-cprDe_highP_stopTarg:cprDeHighPStopTargTCFilter:TimeClusterFilter                     6.342e-06    7.98873e-06   0.000101133    7.264e-06    2.83887e-06     20000   
-tprHelixUe:tprHelixUePS:PrescaleEvent                                                 1.753e-06    2.99698e-06    0.0100206     2.214e-06    7.08501e-05     20000   
-tprHelixUe:TTtimeClusterFinderUe:TimeClusterFinder                                   3.0768e-05    0.00208574     0.0450183     0.0011725     0.0029038      20000   
-tprHelixUe:tprHelixUeTCFilter:TimeClusterFilter                                       8.035e-06    1.53941e-05    0.0100396    1.3355e-05    8.2936e-05      20000   
-tprHelixUe:TThelixFinderUe:RobustHelixFinder                                         1.1162e-05    0.000699713    0.0254203    0.000352085   0.00127439      19888   
-tprHelixUe:TTHelixMergerUe:MergeHelices                                               1.083e-05    1.87374e-05   0.00905783     1.602e-05    6.51189e-05     19888   
-tprHelixUe:tprHelixUeHSFilter:HelixFilter                                             5.801e-06    1.12006e-05    0.0130265     8.176e-06    0.000134928     19888   
-tprHelixDe:tprHelixDePS:PrescaleEvent                                                 1.643e-06    3.51544e-06   0.000219888    3.296e-06    2.44966e-06     20000   
-tprHelixDe:TTtimeClusterFinder:TimeClusterFinder                                     2.7171e-05    0.00200825     0.0471349    0.00110591    0.00284386      20000   
-tprHelixDe:tprHelixDeTCFilter:TimeClusterFilter                                       7.765e-06    1.52148e-05   0.00212485    1.3836e-05    2.15047e-05     20000   
-tprHelixDe:TThelixFinder:RobustHelixFinder                                            9.127e-06    0.000757194    0.0776411    0.000365656   0.00147934      19893   
-tprHelixDe:TTHelixMergerDe:MergeHelices                                               9.337e-06    1.93628e-05    0.0102225     1.521e-05    0.000143587     19893   
-tprHelixDe:tprHelixDeHSFilter:HelixFilter                                             5.23e-06     9.10685e-06   0.000213867    7.865e-06    4.26638e-06     19893   
-tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledPS:PrescaleEvent                       1.744e-06    4.12538e-06    0.0100195     3.367e-06    7.08769e-05     20000   
-tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTCFilter:TimeClusterFilter             6.734e-06    1.35308e-05    0.0100414    1.1341e-05    0.000112416     20000   
-tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledHSFilter:HelixFilter                   4.909e-06    7.03447e-06   0.000261558    6.232e-06     3.456e-06      19893   
-tprHelixDe_ipa:tprHelixDeIpaPS:PrescaleEvent                                          1.693e-06    2.63264e-06   0.000168701    2.395e-06    2.06132e-06     20000   
-tprHelixDe_ipa:tprHelixDeIpaTCFilter:TimeClusterFilter                                6.312e-06    9.76629e-06    0.0027604     8.767e-06    2.16077e-05     20000   
-tprHelixDe_ipa:tprHelixDeIpaHSFilter:HelixFilter                                      4.609e-06    7.3923e-06     0.0109958     5.741e-06    9.03335e-05     19893   
-tprDe_lowP_stopTarg:tprDeLowPStopTargPS:PrescaleEvent                                 1.743e-06    3.9986e-06     0.0100216     2.234e-06    0.000122716     20000   
-tprDe_lowP_stopTarg:tprDeLowPStopTargTCFilter:TimeClusterFilter                       6.552e-06    1.02536e-05    0.0100343     8.407e-06    0.000100326     20000   
-tprDe_lowP_stopTarg:tprDeLowPStopTargHSFilter:HelixFilter                             5.029e-06    7.74089e-06    0.0100248     6.392e-06    7.15074e-05     19937   
-tprDe_highP:tprDeHighPPS:PrescaleEvent                                                1.713e-06    2.55928e-06   0.000214829    2.234e-06    2.05836e-06     20000   
-tprDe_highP:tprDeHighPTCFilter:TimeClusterFilter                                      6.452e-06    9.38798e-06   0.00403327     8.115e-06    2.86479e-05     20000   
-tprDe_highP:tprDeHighPHSFilter:HelixFilter                                            4.849e-06    7.67018e-06    0.0100392     6.082e-06    7.12199e-05     19893   
-tprDe_highP_stopTarg:tprDeHighPStopTargPS:PrescaleEvent                               1.673e-06    2.4758e-06    0.000210049    2.255e-06    1.88199e-06     20000   
-tprDe_highP_stopTarg:tprDeHighPStopTargTCFilter:TimeClusterFilter                     6.763e-06    1.00691e-05    0.0100267     8.335e-06    8.59296e-05     20000   
-tprDe_highP_stopTarg:tprDeHighPStopTargHSFilter:HelixFilter                           4.659e-06    7.6661e-06     0.0170309     5.921e-06    0.00012078      19893   
-mprDe_highP_stopTarg:mprDeHighPStopTargPS:PrescaleEvent                               1.673e-06    2.43539e-06   0.00023085     2.205e-06    2.30143e-06     20000   
-mprDe_highP_stopTarg:mprDeHighPStopTargTCFilter:TimeClusterFilter                     6.703e-06    1.18586e-05    0.010364      8.736e-06    0.000104254     20000   
-mprDe_highP_stopTarg:TTRobustMultiHelixFinder:RobustMultiHelixFinder                 1.8144e-05     0.0046277     0.240602     0.00155733     0.010393       19893   
-mprDe_highP_stopTarg:TTMprHelixMergerDe:MergeHelices                                 1.3285e-05    0.00017479     0.0165049    4.7971e-05    0.000489414     19893   
-mprDe_highP_stopTarg:mprDeHighPStopTargHSFilter:HelixFilter                           5.65e-06     2.45618e-05    0.0120311    1.7303e-05    0.000156127     19893   
-mprDe_highP_stopTarg:TTMprKSFDe:LoopHelixFit                                         0.000135458    0.011484      0.129328      0.0078875     0.0112287      12558   
-mprDe_highP_stopTarg:mprDeHighPStopTargKSFilter:KalSeedFilter                         8.526e-06    2.71377e-05    0.0140525    2.0098e-05    0.000204912     12558   
-[art]:TriggerResults:TriggerResultInserter                                            3.657e-06    5.58153e-06   0.00608466     4.609e-06    4.31251e-05     20000   
-cprHelixUe:TTCalHelixFinderUe:CalHelixFinder                                         3.3885e-05    0.000214478    0.0105343    0.000142882   0.000317788     1738    
-cprHelixUe:TTCalHelixMergerUe:MergeHelices                                           1.1301e-05    1.49116e-05   0.000152661   1.3661e-05    5.01651e-06     1738    
-cprHelixUe:cprHelixUeHSFilter:HelixFilter                                             6.403e-06    8.52802e-06   5.4323e-05    7.7355e-06    2.73315e-06     1738    
-cprHelixDe:TTCalHelixFinderDe:CalHelixFinder                                         2.4467e-05    0.00023554     0.0105561    0.000142191   0.000482969     1794    
-cprHelixDe:TTCalHelixMergerDe:MergeHelices                                            1.059e-05    2.33409e-05    0.0150282    1.3756e-05    0.000354381     1794    
-cprHelixDe:cprHelixDeHSFilter:HelixFilter                                             6.052e-06    1.40343e-05    0.0100495     7.434e-06    0.000237022     1794    
-cprDe_lowP_stopTarg:cprDeLowPStopTargHSFilter:HelixFilter                             5.571e-06    7.49174e-06   4.3533e-05     6.743e-06    2.46836e-06     1794    
-cprDe_highP:cprDeHighPHSFilter:HelixFilter                                            5.04e-06     1.3744e-05     0.0120309    6.2375e-06    0.000283812     1794    
-cprDe_highP_stopTarg:cprDeHighPStopTargHSFilter:HelixFilter                           5.209e-06    7.28789e-06   0.000203267    6.442e-06    5.41205e-06     1794    
-tprHelixDe:tprHelixDeTriggerInfoMerger:MergeTriggerInfo                              1.4868e-05    2.48665e-05   0.00154796    2.1862e-05    4.08529e-05     1446    
-tprDe_lowP_stopTarg:TTKSFDe:LoopHelixFit                                             0.000166928   0.00194788     0.0227556    0.00148056    0.00190494      1774    
-tprDe_lowP_stopTarg:tprDeLowPStopTargKSFilter:KalSeedFilter                           8.607e-06    1.55001e-05    4.652e-05    1.49185e-05   4.97462e-06     1774    
-mprDe_highP_stopTarg:mprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo            1.8204e-05    6.29295e-05    0.0100767    3.01425e-05   0.000540833      344    
-tprDe_lowP_stopTarg:tprDeLowPStopTargTriggerInfoMerger:MergeTriggerInfo              1.7022e-05    2.06141e-05   3.8523e-05    1.9106e-05    4.18096e-06      141    
-tprHelixUe:tprHelixUeTriggerInfoMerger:MergeTriggerInfo                               1.592e-05    2.69286e-05   0.00058315    2.5954e-05    1.43551e-05     1940    
-aprHelix:aprHelixTriggerInfoMerger:MergeTriggerInfo                                  1.6871e-05    2.6256e-05    5.5917e-05     2.58e-05     5.57589e-06      279    
-apr_ue_highP:TTAprUeKSF:LoopHelixFit                                                 0.000153242   0.000836844    0.0170937    0.000541861   0.00134056       221    
-apr_ue_highP:aprUeHighPKSFilter:KalSeedFilter                                         7.524e-06    1.21762e-05   0.000192827    1.06e-05     1.24802e-05      221    
-apr_highP:TTAprKSF:LoopHelixFit                                                      0.000136329   0.000868036    0.0119303    0.000602126   0.00130637       84     
-apr_highP:aprHighPKSFilter:KalSeedFilter                                              5.211e-06    8.13764e-06   2.2181e-05     6.864e-06    2.87493e-06      221    
-tprDe_highP:tprDeHighPKSFilter:KalSeedFilter                                          5.27e-06     8.88493e-06   9.9318e-05     8.256e-06    4.62798e-06     1125    
-tprDe_highP_stopTarg:tprDeHighPStopTargKSFilter:KalSeedFilter                          5.1e-06     7.44053e-06   2.5449e-05    6.8035e-06    2.47698e-06      712    
-tprHelixDe_ipa:tprHelixDeIpaTriggerInfoMerger:MergeTriggerInfo                        1.088e-05    2.9582e-05    0.00708612    1.45225e-05   0.000300829      552    
-tprDe_highP:TTKSFDe:LoopHelixFit                                                     0.000185144   0.00173385     0.0239515    0.00118786    0.00244326       121    
-cprHelixDe:cprHelixDeTriggerInfoMerger:MergeTriggerInfo                               1.614e-05    2.60829e-05   6.0625e-05    2.5715e-05    7.71411e-06      82     
-cprDe_highP:TTCalSeedFitDe:LoopHelixFit                                              0.00023672    0.000624635   0.00129803    0.000375966   0.000409115       5     
-cprDe_highP:cprDeHighPKSFilter:KalSeedFilter                                          5.51e-06     7.83526e-06   1.7212e-05     6.593e-06    2.54807e-06      46     
-tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTriggerInfoMerger:MergeTriggerInfo    1.2434e-05    2.00831e-05   0.000175965   1.6862e-05    1.45461e-05      147    
-apr_lowP_stopTarg:TTAprKSF:LoopHelixFit                                              0.000177959   0.00081267    0.00278323    0.000581402   0.000601238      184    
-apr_lowP_stopTarg:aprLowPStopTargKSFilter:KalSeedFilter                               5.27e-06     1.35005e-05    5.238e-05    1.24685e-05   5.21636e-06      194    
-cprDe_lowP_stopTarg:TTCalSeedFitDe:LoopHelixFit                                      0.000146189   0.000954143   0.00286931    0.00101737    0.000635231      78     
-cprDe_lowP_stopTarg:cprDeLowPStopTargKSFilter:KalSeedFilter                           9.409e-06    1.43227e-05   4.0457e-05    1.40825e-05   4.8563e-06       78     
-apr_highP_stopTarg:aprHighPStopTargKSFilter:KalSeedFilter                             5.11e-06     6.75046e-06   2.9315e-05     5.611e-06    3.5905e-06       71     
-tprDe_lowP_stopTarg:TThelixFinder:RobustHelixFinder                                   9.407e-06    2.98873e-05   0.000287358   1.81445e-05   4.2555e-05       44     
-tprDe_lowP_stopTarg:TTHelixMergerDe:MergeHelices                                     1.0931e-05    1.36808e-05    2.105e-05    1.32105e-05   2.10694e-06      44     
-cprDe_lowP_stopTarg:cprDeLowPStopTargTriggerInfoMerger:MergeTriggerInfo              1.7373e-05    2.09515e-05   3.0847e-05    1.9116e-05    4.01838e-06      20     
-cprDe_highP_stopTarg:cprDeHighPStopTargKSFilter:KalSeedFilter                         5.321e-06     7.09e-06      8.987e-06    7.4345e-06    1.34697e-06      20     
-apr_lowP_stopTarg:aprLowPStopTargTriggerInfoMerger:MergeTriggerInfo                  1.5019e-05    1.94088e-05   2.9726e-05    1.8876e-05    2.62987e-06      23     
-apr_lowP_multiHelix:TTAprKSF:LoopHelixFit                                            0.00098235    0.00206871    0.00413907    0.00181653    0.00101495       10     
-apr_lowP_multiHelix:aprLowPMultiHelixKSFilter:KalSeedFilter                           1.068e-05    1.47774e-05   2.3054e-05    1.49185e-05   3.43053e-06      10     
-apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkKSFilter:KalSeedFilter            6.642e-06    8.0194e-06     9.198e-06     8.537e-06    1.1376e-06        5     
-tprDe_highP:tprDeHighPTriggerInfoMerger:MergeTriggerInfo                             1.4417e-05    1.68182e-05   1.8605e-05    1.7494e-05    1.70455e-06       5     
-apr_highP:aprHighPTriggerInfoMerger:MergeTriggerInfo                                 1.8556e-05    1.88615e-05   1.9167e-05    1.88615e-05    3.055e-07        2     
-cprDe_highP:cprDeHighPTriggerInfoMerger:MergeTriggerInfo                              1.586e-05     1.586e-05     1.586e-05     1.586e-05         0            1     
-cprDe_highP_stopTarg:cprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo            1.3625e-05    1.3625e-05    1.3625e-05    1.3625e-05         0            1     
-apr_highP_stopTarg:aprHighPStopTargTriggerInfoMerger:MergeTriggerInfo                 1.557e-05     1.557e-05     1.557e-05     1.557e-05         0            1     
-tprDe_highP_stopTarg:tprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo            1.3585e-05    1.3585e-05    1.3585e-05    1.3585e-05         0            1     
-apr_lowP_multiHelix:aprLowPMultiHelixTriggerInfoMerger:MergeTriggerInfo              2.1622e-05    2.1622e-05    2.1622e-05    2.1622e-05         0            1     
+source:RootInput(read)                                                               6.7499e-05    0.000114244   0.00300049    0.00010498    5.17006e-05     20000   
+caloHitRec_N0Source:processCFOData:EventHeaderFromCFOFragment                        1.1032e-05    1.39197e-05   0.000352654   1.2544e-05    5.21905e-06     20000   
+caloHitRec_N0Source:caloHitRecN0SourcePS:PrescaleEvent                                8.837e-06    1.27519e-05   0.000915531   1.1072e-05    1.19128e-05     20000   
+minBias_CDCount:minBiasCDCountPS:PrescaleEvent                                        1.853e-06    2.49893e-06   2.6902e-05     2.334e-06    1.10596e-06     20000   
+minBias_SDCount:minBiasSDCountPS:PrescaleEvent                                        1.473e-06    1.96737e-06   3.0809e-05     1.833e-06    9.68056e-07     20000   
+cstCosmicTrackSeed:cstCosmicTrackSeedPS:PrescaleEvent                                 1.502e-06    1.97256e-06   2.6571e-05     1.823e-06    9.41427e-07     20000   
+cstTimeCluster:cstTimeClusterPS:PrescaleEvent                                         1.433e-06    1.87674e-06   2.9185e-05     1.723e-06    1.03718e-06     20000   
+caloFast_RMC:caloFastRMCPS:PrescaleEvent                                              1.503e-06    2.01063e-06   3.2812e-05     1.813e-06    1.21349e-06     20000   
+caloFast_RMC:CaloHitMakerFast:CaloHitMakerFast                                       7.6125e-05    0.000465924   0.00431192    0.000387131   0.000287867     20000   
+caloFast_RMC:CaloClusterFast:CaloClusterFast                                          9.669e-06    6.26717e-05   0.000904871   5.22845e-05   3.99882e-05     20000   
+caloFast_RMC:caloFastRMCFilter:CaloClusterCounterFilter                               6.793e-06    8.80498e-06   0.000508543    7.986e-06    5.66445e-06     20000   
+caloFast_cosmic:caloFastCosmicPS:PrescaleEvent                                        2.494e-06    3.55084e-06   3.3203e-05     3.317e-06    1.39403e-06     20000   
+caloFast_cosmic:caloFastCosmicFilter:CaloCosmicCalib                                  4.419e-06    5.91868e-06   0.000178772    5.44e-06     2.57209e-06     20000   
+caloFast_MVANNCE:caloFastMVANNCEPS:PrescaleEvent                                      1.703e-06    2.25282e-06   5.6168e-05     2.055e-06    1.16212e-06     20000   
+caloFast_MVANNCE:caloFastMVANNCEFilter:FilterEcalNNTrigger                            5.01e-06     7.45368e-06   0.000102707    6.994e-06    2.7008e-06      20000   
+caloFast_photon:caloFastPhotonPS:PrescaleEvent                                        1.673e-06    2.1771e-06    5.5006e-05     1.984e-06    1.20936e-06     20000   
+caloFast_photon:caloFastPhotonFilter:CaloLikelihood                                   5.06e-06     8.21328e-06   0.00175818     6.142e-06    1.64541e-05     20000   
+aprHelix:aprLowPStopTargPS:PrescaleEvent                                              1.784e-06    2.59111e-06   0.00219728     2.294e-06    1.55729e-05     20000   
+aprHelix:TTmakeSD:StrawDigisFromArtdaqFragments                                       8.366e-06    1.05669e-05   0.000228858    9.538e-06    3.60977e-06     20000   
+aprHelix:TTmakeSH:StrawHitReco                                                       3.8924e-05    0.000461273    0.897031     0.000355545   0.00634476      20000   
+aprHelix:TTmakePH:CombineStrawHits                                                    8.696e-06    7.58198e-05   0.00124924    5.90025e-05   5.92504e-05     20000   
+aprHelix:TTflagPH:DeltaFinder                                                        8.2708e-05    0.000455451    0.0050174    0.000332977   0.000391668     20000   
+aprHelix:TTTZClusterFinder:TZClusterFinder                                           1.2575e-05    9.24599e-05   0.000783778   6.61115e-05   8.07544e-05     20000   
+aprHelix:aprHelixTCFilter:TimeClusterFilter                                          1.0049e-05    1.38607e-05   0.00132967    1.2934e-05    1.01924e-05     20000   
+aprHelix:TTAprHelixFinder:AgnosticHelixFinder                                        1.1131e-05    0.000260175    0.0119506    0.000100462   0.000437589     16392   
+aprHelix:TTAprHelixMerger:MergeHelices                                               1.1753e-05    1.49833e-05   0.000333638   1.3666e-05    5.69007e-06     16392   
+aprHelix:aprHelixHSFilter:HelixFilter                                                 6.041e-06    7.88446e-06   6.5394e-05     7.125e-06    2.61791e-06     16392   
+apr_lowP_multiHelix:aprLowPMultiHelixPS:PrescaleEvent                                 2.466e-06    3.48687e-06   0.000144126    3.246e-06    1.75385e-06     20000   
+apr_lowP_multiHelix:aprLowPMultiHelixTCFilter:TimeClusterFilter                       7.585e-06    1.05182e-05   0.000171868    9.93e-06     3.00253e-06     20000   
+apr_lowP_multiHelix:aprLowPMultiHelixHSFilter:HelixFilter                             5.29e-06     6.96941e-06   0.000184914    6.261e-06    2.89714e-06     16392   
+apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkPS:PrescaleEvent                  1.714e-06    2.39112e-06   0.000195364    2.174e-06    1.96791e-06     20000   
+apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkTCFilter:TimeClusterFilter        6.903e-06    8.81469e-06   0.000200795    8.205e-06    2.86198e-06     20000   
+apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkHSFilter:HelixFilter              5.039e-06    6.47976e-06   0.000380578    5.831e-06    4.34614e-06     16392   
+apr_lowP_stopTarg:aprLowPStopTargTCFilter:TimeClusterFilter                           6.413e-06    8.16174e-06   9.7838e-05     7.585e-06    2.5328e-06      20000   
+apr_lowP_stopTarg:aprLowPStopTargHSFilter:HelixFilter                                 4.588e-06    6.0398e-06    0.000212306   5.4005e-06    3.12821e-06     16392   
+apr_ue_highP:aprUeHighPPS:PrescaleEvent                                               1.743e-06    2.34117e-06   9.5643e-05     2.134e-06    1.2966e-06      20000   
+apr_ue_highP:aprUeHighPTCFilter:TimeClusterFilter                                     6.261e-06    7.96264e-06   0.000253845    7.265e-06    3.40017e-06     20000   
+apr_ue_highP:aprUeHighPHSFilter:HelixFilter                                           4.669e-06    6.01256e-06   0.000200043    5.32e-06     2.84133e-06     16392   
+apr_highP:aprHighPPS:PrescaleEvent                                                    1.684e-06    2.24471e-06   0.00018853     2.054e-06    2.00696e-06     20000   
+apr_highP:aprHighPTCFilter:TimeClusterFilter                                          6.223e-06    7.87388e-06   6.4203e-05     7.244e-06    2.45056e-06     20000   
+apr_highP:aprHighPHSFilter:HelixFilter                                                4.619e-06    5.91865e-06   0.000134297    5.291e-06    2.34438e-06     16392   
+apr_highP_stopTarg:aprHighPStopTargPS:PrescaleEvent                                   1.654e-06    2.22766e-06   3.3063e-05     2.014e-06    1.1005e-06      20000   
+apr_highP_stopTarg:aprHighPStopTargTCFilter:TimeClusterFilter                         6.352e-06    7.80786e-06   7.0686e-05     7.234e-06    2.29354e-06     20000   
+apr_highP_stopTarg:aprHighPStopTargHSFilter:HelixFilter                               4.518e-06    5.79295e-06   6.2879e-05     5.229e-06    2.08436e-06     16392   
+cprHelixUe:cprHelixUePS:PrescaleEvent                                                 1.713e-06    2.24942e-06   5.0587e-05     2.074e-06    1.08892e-06     20000   
+cprHelixUe:TTCalTimePeakFinderUe:CalTimePeakFinder                                    8.726e-06    1.31483e-05   0.000236482   1.0209e-05    8.76099e-06     20000   
+cprHelixUe:cprHelixUeTCFilter:TimeClusterFilter                                       7.345e-06    9.00038e-06   0.000139096    8.346e-06    2.63708e-06     20000   
+cprHelixDe:cprHelixDePS:PrescaleEvent                                                 1.733e-06    2.28448e-06   4.0838e-05     2.094e-06    1.07184e-06     20000   
+cprHelixDe:TTCalTimePeakFinder:CalTimePeakFinder                                      6.813e-06    1.04463e-05   0.000228307    7.724e-06    8.18862e-06     20000   
+cprHelixDe:cprHelixDeTCFilter:TimeClusterFilter                                       6.723e-06    8.24715e-06   0.000226603    7.545e-06    2.91328e-06     20000   
+cprDe_lowP_stopTarg:cprDeLowPStopTargPS:PrescaleEvent                                 1.713e-06    2.24578e-06   0.000105742    2.034e-06    1.27105e-06     20000   
+cprDe_lowP_stopTarg:cprDeLowPStopTargTCFilter:TimeClusterFilter                       6.733e-06    8.28111e-06   0.000209319    7.564e-06    3.31058e-06     20000   
+cprDe_highP:cprDeHighPPS:PrescaleEvent                                                1.663e-06    2.19326e-06   0.000179073    2.003e-06    1.60816e-06     20000   
+cprDe_highP:cprDeHighPTCFilter:TimeClusterFilter                                      6.532e-06    7.95666e-06   0.000141782    7.324e-06    2.59332e-06     20000   
+cprDe_highP_stopTarg:cprDeHighPStopTargPS:PrescaleEvent                               1.623e-06    2.19183e-06   0.000207507    1.964e-06    2.58004e-06     20000   
+cprDe_highP_stopTarg:cprDeHighPStopTargTCFilter:TimeClusterFilter                     6.212e-06    7.58158e-06   0.000179182    7.014e-06    2.59444e-06     20000   
+tprHelixUe:tprHelixUePS:PrescaleEvent                                                 1.783e-06    2.38174e-06   0.000822822    2.134e-06    5.90323e-06     20000   
+tprHelixUe:TTtimeClusterFinderUe:TimeClusterFinder                                   2.9727e-05    0.00187576     0.0310297    0.00111868    0.00234147      20000   
+tprHelixUe:tprHelixUeTCFilter:TimeClusterFilter                                       7.985e-06    1.36221e-05   0.00088388    1.2775e-05    1.0835e-05      20000   
+tprHelixUe:TThelixFinderUe:RobustHelixFinder                                         1.0199e-05    0.00063255     0.0167349    0.000340692   0.000942201     19888   
+tprHelixUe:TTHelixMergerUe:MergeHelices                                               1.051e-05    1.74294e-05   0.000357183   1.5569e-05    7.77978e-06     19888   
+tprHelixUe:tprHelixUeHSFilter:HelixFilter                                             5.841e-06    9.17704e-06   0.000199521    7.985e-06    3.40069e-06     19888   
+tprHelixDe:tprHelixDePS:PrescaleEvent                                                 1.743e-06    3.33226e-06   0.000186416    3.155e-06    2.74403e-06     20000   
+tprHelixDe:TTtimeClusterFinder:TimeClusterFinder                                     2.6631e-05    0.00179474     0.0283617    0.00105337    0.00228763      20000   
+tprHelixDe:tprHelixDeTCFilter:TimeClusterFilter                                       7.714e-06    1.41355e-05   0.00273931    1.3126e-05    2.4272e-05      20000   
+tprHelixDe:TThelixFinder:RobustHelixFinder                                            8.125e-06    0.000683164    0.0763501    0.000355759   0.00116783      19893   
+tprHelixDe:TTHelixMergerDe:MergeHelices                                               9.257e-06    1.64908e-05   0.000373103   1.4739e-05    7.91334e-06     19893   
+tprHelixDe:tprHelixDeHSFilter:HelixFilter                                             5.23e-06     8.74488e-06   0.00093681     7.555e-06    7.30282e-06     19893   
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledPS:PrescaleEvent                       1.864e-06    3.3769e-06    0.000361291    3.166e-06    3.70413e-06     20000   
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTCFilter:TimeClusterFilter             6.643e-06    1.16201e-05   0.000364086   1.1001e-05    5.63851e-06     20000   
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledHSFilter:HelixFilter                   4.88e-06     6.76478e-06   0.000198238    6.041e-06    3.1269e-06      19893   
+tprHelixDe_ipa:tprHelixDeIpaPS:PrescaleEvent                                          1.723e-06    2.42233e-06   0.000179704    2.244e-06    1.92813e-06     20000   
+tprHelixDe_ipa:tprHelixDeIpaTCFilter:TimeClusterFilter                                6.552e-06    9.14116e-06   0.000317517    8.495e-06    3.72502e-06     20000   
+tprHelixDe_ipa:tprHelixDeIpaHSFilter:HelixFilter                                      4.698e-06    6.38316e-06   0.00019322     5.681e-06    2.69204e-06     19893   
+tprDe_lowP_stopTarg:tprDeLowPStopTargPS:PrescaleEvent                                 1.633e-06    2.26278e-06   6.9033e-05     2.085e-06    1.09083e-06     20000   
+tprDe_lowP_stopTarg:tprDeLowPStopTargTCFilter:TimeClusterFilter                       6.512e-06    8.72478e-06   0.000256791    8.065e-06    3.70405e-06     20000   
+tprDe_lowP_stopTarg:tprDeLowPStopTargHSFilter:HelixFilter                              5.1e-06     7.12036e-06   0.00174519     6.142e-06    1.26555e-05     19937   
+tprDe_highP:tprDeHighPPS:PrescaleEvent                                                1.634e-06    2.3593e-06    4.9815e-05     2.064e-06    1.20524e-06     20000   
+tprDe_highP:tprDeHighPTCFilter:TimeClusterFilter                                      6.523e-06    8.99622e-06   0.000411336    7.92e-06     6.25668e-06     20000   
+tprDe_highP:tprDeHighPHSFilter:HelixFilter                                            4.789e-06    6.81485e-06   0.000214461    5.651e-06    3.72736e-06     19893   
+tprDe_highP_stopTarg:tprDeHighPStopTargPS:PrescaleEvent                               1.603e-06    2.17104e-06    4.211e-05     1.983e-06    1.01429e-06     20000   
+tprDe_highP_stopTarg:tprDeHighPStopTargTCFilter:TimeClusterFilter                     6.592e-06    8.76299e-06   0.000272812    7.965e-06    5.22542e-06     20000   
+tprDe_highP_stopTarg:tprDeHighPStopTargHSFilter:HelixFilter                           4.849e-06    6.51985e-06   0.000138235    5.611e-06    2.50979e-06     19893   
+mprDe_highP_stopTarg:mprDeHighPStopTargPS:PrescaleEvent                               1.583e-06    2.10168e-06   3.8825e-05     1.924e-06    1.09088e-06     20000   
+mprDe_highP_stopTarg:mprDeHighPStopTargTCFilter:TimeClusterFilter                     6.903e-06    1.03755e-05   0.000485508    8.316e-06    1.71302e-05     20000   
+mprDe_highP_stopTarg:TTRobustMultiHelixFinder:RobustMultiHelixFinder                 1.7824e-05    0.00413682     0.208055     0.00149099    0.00888956      19893   
+mprDe_highP_stopTarg:TTMprHelixMergerDe:MergeHelices                                 1.3356e-05    0.000154425   0.00550593    4.5967e-05    0.000311303     19893   
+mprDe_highP_stopTarg:mprDeHighPStopTargHSFilter:HelixFilter                           5.55e-06     2.11116e-05   0.00103367    1.6913e-05    1.67082e-05     19893   
+mprDe_highP_stopTarg:TTMprKSFDe:LoopHelixFit                                         0.000135329    0.0101754     0.0824757    0.00723645    0.00929334      12558   
+mprDe_highP_stopTarg:mprDeHighPStopTargKSFilter:KalSeedFilter                         8.056e-06    2.06782e-05   0.000840577   1.8094e-05    1.31689e-05     12558   
+[art]:TriggerResults:TriggerResultInserter                                            3.668e-06    4.85845e-06   0.000187669    4.378e-06    2.4994e-06      20000   
+cprHelixUe:TTCalHelixFinderUe:CalHelixFinder                                         2.7111e-05    0.00020635    0.00288544    0.000143254   0.000194206     1738    
+cprHelixUe:TTCalHelixMergerUe:MergeHelices                                            1.067e-05    1.46521e-05   4.5798e-05    1.36815e-05   3.50035e-06     1738    
+cprHelixUe:cprHelixUeHSFilter:HelixFilter                                             5.871e-06    7.99691e-06   5.6759e-05    7.3435e-06    2.59642e-06     1738    
+cprHelixDe:TTCalHelixFinderDe:CalHelixFinder                                         2.3915e-05    0.000209563   0.00289873    0.000140073   0.000210843     1794    
+cprHelixDe:TTCalHelixMergerDe:MergeHelices                                            1.031e-05    1.39534e-05   5.5897e-05     1.297e-05    3.47133e-06     1794    
+cprHelixDe:cprHelixDeHSFilter:HelixFilter                                             5.982e-06    8.31616e-06   0.000190593    7.364e-06    5.01557e-06     1794    
+cprDe_lowP_stopTarg:cprDeLowPStopTargHSFilter:HelixFilter                             5.29e-06     7.28162e-06   2.9908e-05     6.572e-06    2.45797e-06     1794    
+cprDe_highP:cprDeHighPHSFilter:HelixFilter                                            4.809e-06    6.80943e-06    4.724e-05     6.127e-06    2.37261e-06     1794    
+cprDe_highP_stopTarg:cprDeHighPStopTargHSFilter:HelixFilter                           4.899e-06    6.9083e-06    2.8425e-05    6.3525e-06    2.15871e-06     1794    
+tprHelixDe:tprHelixDeTriggerInfoMerger:MergeTriggerInfo                              1.4217e-05    2.18253e-05   0.000359186   1.86855e-05   1.49284e-05     1446    
+tprDe_lowP_stopTarg:TTKSFDe:LoopHelixFit                                             0.000161018   0.00172684     0.0113968    0.00142003    0.00125814      1774    
+tprDe_lowP_stopTarg:tprDeLowPStopTargKSFilter:KalSeedFilter                           8.157e-06    1.4092e-05    4.9976e-05    1.3786e-05    4.40773e-06     1774    
+mprDe_highP_stopTarg:mprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo            1.7905e-05    2.9014e-05    0.000117866   2.5073e-05    1.23619e-05      344    
+aprHelix:aprHelixTriggerInfoMerger:MergeTriggerInfo                                  1.6451e-05    2.37945e-05    0.0002406    2.0839e-05    9.70386e-06     1305    
+apr_lowP_stopTarg:TTAprKSF:LoopHelixFit                                              0.000159834   0.00102869    0.00655617    0.00088153    0.000796431      564    
+apr_lowP_stopTarg:aprLowPStopTargKSFilter:KalSeedFilter                               5.02e-06     1.2898e-05    4.1179e-05    1.2174e-05    4.01035e-06      593    
+apr_lowP_stopTarg:aprLowPStopTargTriggerInfoMerger:MergeTriggerInfo                  1.4788e-05    2.15408e-05   6.1467e-05    1.9357e-05    6.35133e-06      131    
+tprDe_lowP_stopTarg:tprDeLowPStopTargTriggerInfoMerger:MergeTriggerInfo              1.6811e-05    1.98292e-05   3.4326e-05    1.8776e-05    3.20059e-06      141    
+tprHelixUe:tprHelixUeTriggerInfoMerger:MergeTriggerInfo                              1.5169e-05    2.25334e-05   0.000227334   1.98935e-05   9.31961e-06     1940    
+apr_ue_highP:TTAprUeKSF:LoopHelixFit                                                 0.000143155   0.000779992   0.00583074    0.000540603   0.000705708      321    
+apr_ue_highP:aprUeHighPKSFilter:KalSeedFilter                                         7.335e-06    1.13743e-05   3.9725e-05     1.055e-05    3.38293e-06      321    
+apr_highP:TTAprKSF:LoopHelixFit                                                      0.000150979   0.000806135   0.00283592    0.000640956   0.000579902      135    
+apr_highP:aprHighPKSFilter:KalSeedFilter                                              5.16e-06     8.54724e-06   3.4295e-05     8.115e-06    3.25317e-06      321    
+tprDe_highP:tprDeHighPKSFilter:KalSeedFilter                                          5.029e-06    8.59207e-06   5.4915e-05     8.066e-06    3.65752e-06     1125    
+tprDe_highP_stopTarg:tprDeHighPStopTargKSFilter:KalSeedFilter                          4.9e-06     7.60114e-06   3.8703e-05     7.324e-06    2.95772e-06      712    
+tprHelixDe_ipa:tprHelixDeIpaTriggerInfoMerger:MergeTriggerInfo                       1.0029e-05    1.60502e-05   0.000345901   1.4332e-05    1.46741e-05      552    
+tprDe_highP:TTKSFDe:LoopHelixFit                                                     0.000186596   0.00146687     0.0060715    0.00115804    0.00120086       121    
+cprHelixDe:cprHelixDeTriggerInfoMerger:MergeTriggerInfo                               1.565e-05    2.2251e-05    5.3111e-05    2.01225e-05   6.48446e-06      82     
+cprDe_highP:TTCalSeedFitDe:LoopHelixFit                                              0.000218538   0.000601762    0.0012877    0.000357604   0.000410985       5     
+cprDe_highP:cprDeHighPKSFilter:KalSeedFilter                                          6.183e-06    9.37396e-06   2.9396e-05    7.2635e-06    4.88808e-06      46     
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTriggerInfoMerger:MergeTriggerInfo    1.1531e-05    1.77511e-05    5.263e-05    1.6061e-05    6.41151e-06      147    
+cprDe_lowP_stopTarg:TTCalSeedFitDe:LoopHelixFit                                      1.9868e-05    0.000838321    0.0029103    0.000791273   0.000597248      78     
+cprDe_lowP_stopTarg:cprDeLowPStopTargKSFilter:KalSeedFilter                           8.266e-06    1.31693e-05   3.8093e-05    1.2344e-05    4.11248e-06      78     
+apr_highP_stopTarg:aprHighPStopTargKSFilter:KalSeedFilter                             5.141e-06    6.70414e-06   1.9949e-05     5.761e-06    2.22374e-06      79     
+tprDe_lowP_stopTarg:TThelixFinder:RobustHelixFinder                                   9.047e-06    3.31593e-05   0.000251581   1.6832e-05    4.82266e-05      44     
+tprDe_lowP_stopTarg:TTHelixMergerDe:MergeHelices                                      1.057e-05    1.36733e-05   2.7373e-05    1.3271e-05    2.72987e-06      44     
+apr_lowP_multiHelix:TTAprKSF:LoopHelixFit                                            0.000361231   0.00204101     0.0054794    0.00156369    0.00140204       29     
+apr_lowP_multiHelix:aprLowPMultiHelixKSFilter:KalSeedFilter                           9.327e-06    1.44763e-05   2.3273e-05    1.4438e-05    3.62065e-06      29     
+apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkKSFilter:KalSeedFilter            6.112e-06    6.84483e-06    9.357e-06     6.437e-06    1.13702e-06       6     
+cprDe_lowP_stopTarg:cprDeLowPStopTargTriggerInfoMerger:MergeTriggerInfo              1.7875e-05    2.04334e-05   3.5989e-05    1.8927e-05    4.39432e-06      19     
+cprDe_highP_stopTarg:cprDeHighPStopTargKSFilter:KalSeedFilter                         5.531e-06    7.6808e-06    1.2014e-05    7.7845e-06    1.76184e-06      20     
+apr_lowP_multiHelix:aprLowPMultiHelixTriggerInfoMerger:MergeTriggerInfo              1.9327e-05    2.02985e-05    2.127e-05    2.02985e-05    9.715e-07        2     
+apr_highP:aprHighPTriggerInfoMerger:MergeTriggerInfo                                 1.7373e-05    2.05627e-05   2.4006e-05    2.0309e-05    2.71385e-06       3     
+tprDe_highP:tprDeHighPTriggerInfoMerger:MergeTriggerInfo                             1.5379e-05    1.8632e-05     2.603e-05    1.7063e-05    3.86095e-06       5     
+cprDe_highP:cprDeHighPTriggerInfoMerger:MergeTriggerInfo                             1.6422e-05    1.6422e-05    1.6422e-05    1.6422e-05         0            1     
+cprDe_highP_stopTarg:cprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo            1.4337e-05    1.4337e-05    1.4337e-05    1.4337e-05         0            1     
+apr_highP_stopTarg:aprHighPStopTargTriggerInfoMerger:MergeTriggerInfo                 1.545e-05     1.545e-05     1.545e-05     1.545e-05         0            1     
+tprDe_highP_stopTarg:tprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo            1.4137e-05    1.4137e-05    1.4137e-05    1.4137e-05         0            1     
 =======================================================================================================================================================================
 DbEngine::endJob
-    Total time in reading DB: 0.925418 s
+    Total time in reading DB: 0.742125 s
     Total time waiting for locks: 1e-06 s
-    Total time in locks: 0.754726 s
-    valcache memory: 58641 b
+    Total time in locks: 0.557499 s
+    valcache memory: 68009 b
   Database cache stats:
     cache nTable : 11
     cache HWM    : 1364957 b
@@ -231,7 +231,7 @@ DbEngine::endJob
     cache nPurged : 0
 
 TrigReport ---------- Event summary -------------
-TrigReport Events total = 20000 passed = 4588 failed = 15412
+TrigReport Events total = 20000 passed = 4896 failed = 15104
 
 TrigReport ---------- Trigger-path summary ------------
 TrigReport    Path ID        Run     Passed     Failed      Error Name
@@ -244,16 +244,16 @@ TrigReport        130      20000       1446      18554          0 tprHelixDe
 TrigReport        131      20000       1940      18060          0 tprHelixUe
 TrigReport        150      20000          1      19999          0 cprDe_highP_stopTarg
 TrigReport        151      20000          1      19999          0 cprDe_highP
-TrigReport        160      20000         20      19980          0 cprDe_lowP_stopTarg
+TrigReport        160      20000         19      19981          0 cprDe_lowP_stopTarg
 TrigReport        170      20000         82      19918          0 cprHelixDe
 TrigReport        171      20000         34      19966          0 cprHelixUe
 TrigReport        180      20000          1      19999          0 apr_highP_stopTarg
-TrigReport        181      20000          2      19998          0 apr_highP
+TrigReport        181      20000          3      19997          0 apr_highP
 TrigReport        185      20000          0      20000          0 apr_ue_highP
-TrigReport        190      20000         23      19977          0 apr_lowP_stopTarg
+TrigReport        190      20000        131      19869          0 apr_lowP_stopTarg
 TrigReport        191      20000          0      20000          0 apr_highP_stopTarg_multiTrk
-TrigReport        192      20000          1      19999          0 apr_lowP_multiHelix
-TrigReport        195      20000        279      19721          0 aprHelix
+TrigReport        192      20000          2      19998          0 apr_lowP_multiHelix
+TrigReport        195      20000       1305      18695          0 aprHelix
 TrigReport        200      20000        471      19529          0 caloFast_photon
 TrigReport        201      20000       1844      18156          0 caloFast_MVANNCE
 TrigReport        202      20000          0      20000          0 caloFast_cosmic
@@ -282,8 +282,8 @@ TrigReport        195      20000      20000          0          0 TTTZClusterFin
 TrigReport        195      20000      16392       3608          0 aprHelixTCFilter
 TrigReport        195      16392      16392          0          0 TTAprHelixFinder
 TrigReport        195      16392      16392          0          0 TTAprHelixMerger
-TrigReport        195      16392        279      16113          0 aprHelixHSFilter
-TrigReport        195        279        279          0          0 aprHelixTriggerInfoMerger
+TrigReport        195      16392       1305      15087          0 aprHelixHSFilter
+TrigReport        195       1305       1305          0          0 aprHelixTriggerInfoMerger
 
 TrigReport ---------- Modules in path: apr_highP ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -299,10 +299,10 @@ TrigReport        181      20000      20000          0          0 TTTZClusterFin
 TrigReport        181      20000      16392       3608          0 aprHighPTCFilter
 TrigReport        181      16392      16392          0          0 TTAprHelixFinder
 TrigReport        181      16392      16392          0          0 TTAprHelixMerger
-TrigReport        181      16392        221      16171          0 aprHighPHSFilter
-TrigReport        181        221        221          0          0 TTAprKSF
-TrigReport        181        221          2        219          0 aprHighPKSFilter
-TrigReport        181          2          2          0          0 aprHighPTriggerInfoMerger
+TrigReport        181      16392        321      16071          0 aprHighPHSFilter
+TrigReport        181        321        321          0          0 TTAprKSF
+TrigReport        181        321          3        318          0 aprHighPKSFilter
+TrigReport        181          3          3          0          0 aprHighPTriggerInfoMerger
 
 TrigReport ---------- Modules in path: apr_highP_stopTarg ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -318,9 +318,9 @@ TrigReport        180      20000      20000          0          0 TTTZClusterFin
 TrigReport        180      20000      16392       3608          0 aprHighPStopTargTCFilter
 TrigReport        180      16392      16392          0          0 TTAprHelixFinder
 TrigReport        180      16392      16392          0          0 TTAprHelixMerger
-TrigReport        180      16392         71      16321          0 aprHighPStopTargHSFilter
-TrigReport        180         71         71          0          0 TTAprKSF
-TrigReport        180         71          1         70          0 aprHighPStopTargKSFilter
+TrigReport        180      16392         79      16313          0 aprHighPStopTargHSFilter
+TrigReport        180         79         79          0          0 TTAprKSF
+TrigReport        180         79          1         78          0 aprHighPStopTargKSFilter
 TrigReport        180          1          1          0          0 aprHighPStopTargTriggerInfoMerger
 
 TrigReport ---------- Modules in path: apr_highP_stopTarg_multiTrk ------------
@@ -337,9 +337,9 @@ TrigReport        191      20000      20000          0          0 TTTZClusterFin
 TrigReport        191      20000      16392       3608          0 aprHighPStopTargMultiTrkTCFilter
 TrigReport        191      16392      16392          0          0 TTAprHelixFinder
 TrigReport        191      16392      16392          0          0 TTAprHelixMerger
-TrigReport        191      16392          5      16387          0 aprHighPStopTargMultiTrkHSFilter
-TrigReport        191          5          5          0          0 TTAprKSF
-TrigReport        191          5          0          5          0 aprHighPStopTargMultiTrkKSFilter
+TrigReport        191      16392          6      16386          0 aprHighPStopTargMultiTrkHSFilter
+TrigReport        191          6          6          0          0 TTAprKSF
+TrigReport        191          6          0          6          0 aprHighPStopTargMultiTrkKSFilter
 TrigReport        191          0          0          0          0 aprHighPStopTargMultiTrkTriggerInfoMerger
 
 TrigReport ---------- Modules in path: apr_lowP_multiHelix ------------
@@ -356,10 +356,10 @@ TrigReport        192      20000      20000          0          0 TTTZClusterFin
 TrigReport        192      20000      16392       3608          0 aprLowPMultiHelixTCFilter
 TrigReport        192      16392      16392          0          0 TTAprHelixFinder
 TrigReport        192      16392      16392          0          0 TTAprHelixMerger
-TrigReport        192      16392         10      16382          0 aprLowPMultiHelixHSFilter
-TrigReport        192         10         10          0          0 TTAprKSF
-TrigReport        192         10          1          9          0 aprLowPMultiHelixKSFilter
-TrigReport        192          1          1          0          0 aprLowPMultiHelixTriggerInfoMerger
+TrigReport        192      16392         29      16363          0 aprLowPMultiHelixHSFilter
+TrigReport        192         29         29          0          0 TTAprKSF
+TrigReport        192         29          2         27          0 aprLowPMultiHelixKSFilter
+TrigReport        192          2          2          0          0 aprLowPMultiHelixTriggerInfoMerger
 
 TrigReport ---------- Modules in path: apr_lowP_stopTarg ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -375,10 +375,10 @@ TrigReport        190      20000      20000          0          0 TTTZClusterFin
 TrigReport        190      20000      16392       3608          0 aprLowPStopTargTCFilter
 TrigReport        190      16392      16392          0          0 TTAprHelixFinder
 TrigReport        190      16392      16392          0          0 TTAprHelixMerger
-TrigReport        190      16392        194      16198          0 aprLowPStopTargHSFilter
-TrigReport        190        194        194          0          0 TTAprKSF
-TrigReport        190        194         23        171          0 aprLowPStopTargKSFilter
-TrigReport        190         23         23          0          0 aprLowPStopTargTriggerInfoMerger
+TrigReport        190      16392        593      15799          0 aprLowPStopTargHSFilter
+TrigReport        190        593        593          0          0 TTAprKSF
+TrigReport        190        593        131        462          0 aprLowPStopTargKSFilter
+TrigReport        190        131        131          0          0 aprLowPStopTargTriggerInfoMerger
 
 TrigReport ---------- Modules in path: apr_ue_highP ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -394,9 +394,9 @@ TrigReport        185      20000      20000          0          0 TTTZClusterFin
 TrigReport        185      20000      16392       3608          0 aprUeHighPTCFilter
 TrigReport        185      16392      16392          0          0 TTAprHelixFinder
 TrigReport        185      16392      16392          0          0 TTAprHelixMerger
-TrigReport        185      16392        221      16171          0 aprUeHighPHSFilter
-TrigReport        185        221        221          0          0 TTAprUeKSF
-TrigReport        185        221          0        221          0 aprUeHighPKSFilter
+TrigReport        185      16392        321      16071          0 aprUeHighPHSFilter
+TrigReport        185        321        321          0          0 TTAprUeKSF
+TrigReport        185        321          0        321          0 aprUeHighPKSFilter
 TrigReport        185          0          0          0          0 aprUeHighPTriggerInfoMerger
 
 TrigReport ---------- Modules in path: caloFast_MVANNCE ------------
@@ -492,8 +492,8 @@ TrigReport        160       1794       1794          0          0 TTCalHelixFind
 TrigReport        160       1794       1794          0          0 TTCalHelixMergerDe
 TrigReport        160       1794         78       1716          0 cprDeLowPStopTargHSFilter
 TrigReport        160         78         78          0          0 TTCalSeedFitDe
-TrigReport        160         78         20         58          0 cprDeLowPStopTargKSFilter
-TrigReport        160         20         20          0          0 cprDeLowPStopTargTriggerInfoMerger
+TrigReport        160         78         19         59          0 cprDeLowPStopTargKSFilter
+TrigReport        160         19         19          0          0 cprDeLowPStopTargTriggerInfoMerger
 
 TrigReport ---------- Modules in path: cprHelixDe ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -718,8 +718,8 @@ TrigReport          0          0          0          0          0 CstLineFinder
 TrigReport          0          0          0          0          0 CstSimpleTimeCluster
 TrigReport     114744      16392      16392          0          0 TTAprHelixFinder
 TrigReport     114744      16392      16392          0          0 TTAprHelixMerger
-TrigReport        501        278        278          0          0 TTAprKSF
-TrigReport        221        221        221          0          0 TTAprUeKSF
+TrigReport       1028        728        728          0          0 TTAprKSF
+TrigReport        321        321        321          0          0 TTAprUeKSF
 TrigReport       7176       1794       1794          0          0 TTCalHelixFinderDe
 TrigReport       1738       1738       1738          0          0 TTCalHelixFinderUe
 TrigReport       7176       1794       1794          0          0 TTCalHelixMergerDe
@@ -744,16 +744,16 @@ TrigReport     400000      20000      20000          0          0 TTmakeSD
 TrigReport     400000      20000      20000          0          0 TTmakeSH
 TrigReport     140000      20000      20000          0          0 TTtimeClusterFinder
 TrigReport      20000      20000      20000          0          0 TTtimeClusterFinderUe
-TrigReport      16392      16392        279      16113          0 aprHelixHSFilter
+TrigReport      16392      16392       1305      15087          0 aprHelixHSFilter
 TrigReport      20000      20000      16392       3608          0 aprHelixTCFilter
-TrigReport        279        279        279          0          0 aprHelixTriggerInfoMerger
-TrigReport      16392      16392        221      16171          0 aprHighPHSFilter
-TrigReport        221        221          2        219          0 aprHighPKSFilter
+TrigReport       1305       1305       1305          0          0 aprHelixTriggerInfoMerger
+TrigReport      16392      16392        321      16071          0 aprHighPHSFilter
+TrigReport        321        321          3        318          0 aprHighPKSFilter
 TrigReport      20000      20000      20000          0          0 aprHighPPS
-TrigReport      16392      16392         71      16321          0 aprHighPStopTargHSFilter
-TrigReport         71         71          1         70          0 aprHighPStopTargKSFilter
-TrigReport      16392      16392          5      16387          0 aprHighPStopTargMultiTrkHSFilter
-TrigReport          5          5          0          5          0 aprHighPStopTargMultiTrkKSFilter
+TrigReport      16392      16392         79      16313          0 aprHighPStopTargHSFilter
+TrigReport         79         79          1         78          0 aprHighPStopTargKSFilter
+TrigReport      16392      16392          6      16386          0 aprHighPStopTargMultiTrkHSFilter
+TrigReport          6          6          0          6          0 aprHighPStopTargMultiTrkKSFilter
 TrigReport      20000      20000      20000          0          0 aprHighPStopTargMultiTrkPS
 TrigReport      20000      20000      16392       3608          0 aprHighPStopTargMultiTrkTCFilter
 TrigReport          0          0          0          0          0 aprHighPStopTargMultiTrkTriggerInfoMerger
@@ -761,19 +761,19 @@ TrigReport      20000      20000      20000          0          0 aprHighPStopTa
 TrigReport      20000      20000      16392       3608          0 aprHighPStopTargTCFilter
 TrigReport          1          1          1          0          0 aprHighPStopTargTriggerInfoMerger
 TrigReport      20000      20000      16392       3608          0 aprHighPTCFilter
-TrigReport          2          2          2          0          0 aprHighPTriggerInfoMerger
-TrigReport      16392      16392         10      16382          0 aprLowPMultiHelixHSFilter
-TrigReport         10         10          1          9          0 aprLowPMultiHelixKSFilter
+TrigReport          3          3          3          0          0 aprHighPTriggerInfoMerger
+TrigReport      16392      16392         29      16363          0 aprLowPMultiHelixHSFilter
+TrigReport         29         29          2         27          0 aprLowPMultiHelixKSFilter
 TrigReport      20000      20000      20000          0          0 aprLowPMultiHelixPS
 TrigReport      20000      20000      16392       3608          0 aprLowPMultiHelixTCFilter
-TrigReport          1          1          1          0          0 aprLowPMultiHelixTriggerInfoMerger
-TrigReport      16392      16392        194      16198          0 aprLowPStopTargHSFilter
-TrigReport        194        194         23        171          0 aprLowPStopTargKSFilter
+TrigReport          2          2          2          0          0 aprLowPMultiHelixTriggerInfoMerger
+TrigReport      16392      16392        593      15799          0 aprLowPStopTargHSFilter
+TrigReport        593        593        131        462          0 aprLowPStopTargKSFilter
 TrigReport      40000      20000      20000          0          0 aprLowPStopTargPS
 TrigReport      20000      20000      16392       3608          0 aprLowPStopTargTCFilter
-TrigReport         23         23         23          0          0 aprLowPStopTargTriggerInfoMerger
-TrigReport      16392      16392        221      16171          0 aprUeHighPHSFilter
-TrigReport        221        221          0        221          0 aprUeHighPKSFilter
+TrigReport        131        131        131          0          0 aprLowPStopTargTriggerInfoMerger
+TrigReport      16392      16392        321      16071          0 aprUeHighPHSFilter
+TrigReport        321        321          0        321          0 aprUeHighPKSFilter
 TrigReport      20000      20000      20000          0          0 aprUeHighPPS
 TrigReport      20000      20000      16392       3608          0 aprUeHighPTCFilter
 TrigReport          0          0          0          0          0 aprUeHighPTriggerInfoMerger
@@ -798,10 +798,10 @@ TrigReport          1          1          1          0          0 cprDeHighPStop
 TrigReport      20000      20000       1794      18206          0 cprDeHighPTCFilter
 TrigReport          1          1          1          0          0 cprDeHighPTriggerInfoMerger
 TrigReport       1794       1794         78       1716          0 cprDeLowPStopTargHSFilter
-TrigReport         78         78         20         58          0 cprDeLowPStopTargKSFilter
+TrigReport         78         78         19         59          0 cprDeLowPStopTargKSFilter
 TrigReport      20000      20000      20000          0          0 cprDeLowPStopTargPS
 TrigReport      20000      20000       1794      18206          0 cprDeLowPStopTargTCFilter
-TrigReport         20         20         20          0          0 cprDeLowPStopTargTriggerInfoMerger
+TrigReport         19         19         19          0          0 cprDeLowPStopTargTriggerInfoMerger
 TrigReport       1794       1794         82       1712          0 cprHelixDeHSFilter
 TrigReport      20000      20000      20000          0          0 cprHelixDePS
 TrigReport      20000      20000       1794      18206          0 cprHelixDeTCFilter
@@ -861,9 +861,9 @@ TrigReport      20000      20000      19888        112          0 tprHelixUeTCFi
 TrigReport       1940       1940       1940          0          0 tprHelixUeTriggerInfoMerger
 
 TimeReport ---------- Time summary [sec] -------
-TimeReport CPU = 415.357739 Real = 475.427679
+TimeReport CPU = 398.615885 Real = 415.937739
 
 MemReport  ---------- Memory summary [base-10 MB] ------
-MemReport  VmPeak = 1584.56 VmHWM = 602.604
+MemReport  VmPeak = 1591.64 VmHWM = 606.298
 
 Art has completed and will exit with status 0.

--- a/core/filters/trigAprFilters.fcl
+++ b/core/filters/trigAprFilters.fcl
@@ -456,12 +456,12 @@ TrigAprFilters:{
       maxD0: 600
       maxMomentum: 2000
       maxNLoops: 30
-      minAbsLambda: 50
+      minAbsLambda: 40
       minD0: -600
       minHitRatio: 4e-1
-      minMomentum: 50
+      minMomentum: 30
       minNLoops: 0
-      minNStrawHits: 15
+      minNStrawHits: 20
       minPt: 0
       prescaleUsingD0Phi: false
       requireCaloCluster: false
@@ -475,12 +475,12 @@ TrigAprFilters:{
       maxD0: 600
       maxMomentum: 2000
       maxNLoops: 30
-      minAbsLambda: 50
+      minAbsLambda: 40
       minD0: -600
       minHitRatio: 4e-1
-      minMomentum: 50
+      minMomentum: 30
       minNLoops: 0
-      minNStrawHits: 15
+      minNStrawHits: 20
       minPt: 0
       prescaleUsingD0Phi: false
       requireCaloCluster: false

--- a/core/producers/trigAprProducers.fcl
+++ b/core/producers/trigAprProducers.fcl
@@ -41,6 +41,9 @@ TrigAprProducers : {
       HelixSeedCollections   : [ "TTAprHelixMerger" ]
     }
     UsePDGCharge     : false
+    HelixMask: {
+      MinHelixMom : 50
+    }
     FitDirection     : @local::FitDir.downstream
     PrioritizeCaloHits : true
   }

--- a/core/producers/trigCprProducers.fcl
+++ b/core/producers/trigCprProducers.fcl
@@ -243,7 +243,7 @@ TrigCprProducers : {
       }
       UsePDGCharge     : false
       HelixMask: {
-         MinHelixMom : 50
+         MinHelixMom : 40
       }
       FitDirection     : @local::FitDir.downstream
    }

--- a/core/producers/trigCprProducers.fcl
+++ b/core/producers/trigCprProducers.fcl
@@ -242,6 +242,9 @@ TrigCprProducers : {
          FitParticle         : @local::Particle.eminus
       }
       UsePDGCharge     : false
+      HelixMask: {
+         MinHelixMom : 50
+      }
       FitDirection     : @local::FitDir.downstream
       PrioritizeCaloHits : true
    }


### PR DESCRIPTION
Trigger selections in APR Helix filter were changed to recover IPA DIOs and a helix mask was added to the APR and CPR track fitters. 