### PR TITLE
Hit flag checking and CI updates

### DIFF
--- a/ci/check_trigger_results.py
+++ b/ci/check_trigger_results.py
@@ -1,6 +1,7 @@
 # Compare two trigger reports
 
 import sys
+from math import sqrt
 
 #--------------------------------------------------------------
 # Fill the log results
@@ -82,7 +83,7 @@ results_2,timing_2,reference_time_2 = fill_results(f_2, verbose)
 
 # Define the major vs. minor failure thresholds
 count_minor_threshold = 1 # path rate change for minor failure
-count_major_threshold = 4 # path rate change for major failure
+count_major_threshold = 1.5 # path rate change sigma for major failure
 avg_time_minor_threshold = 0.40 # fractional change in time / event
 avg_time_major_threshold = 0.50 # fractional change in time / event
 minor_fail = False
@@ -95,17 +96,20 @@ for path in results_1:
         counts_2 = results_2[path]
         for index in range(len(counts_1)):
             delta = abs(counts_1[index] - counts_2[index])
-            if delta >= count_major_threshold:
+            sigma = sqrt(counts_2[index]) if counts_2[index] > 0 else 2 / count_major_threshold # default to 2 events if none before
+            z = delta / sigma
+            if z >= count_major_threshold:
                 major_fail = True
                 print(">>> Path " + path + " has a major change!")
                 print("Local counts    :", counts_1)
-                print("Reference counts:", counts_2)
+                print("Reference counts:", counts_2, "(delta/sqrt(reference) = %.2f)" % (z))
                 break
             elif delta >= count_minor_threshold:
                 minor_fail = True
                 print(">>> Path " + path + " has a minor change:")
                 print("Local counts    :", counts_1)
                 print("Reference counts:", counts_2)
+                print("Reference counts:", counts_2, "(delta/sqrt(reference) = %.2f)" % (z))
                 break
     else:
         print(">>> New trigger path " + path + " in local found, not in the reference!")

--- a/ci/reference_log_file.log
+++ b/ci/reference_log_file.log
@@ -1,13 +1,13 @@
    ************************** Mu2e Offline **************************
      art v3_15_00    root v6_32_06    KinKal v03_02_01
-     build  /scratch/workspace/GitHubPRTests/mu2e-offline-build-test
-     build  al9-prof-e29-p083    08/13/25 10:59:17
+     build  /exp/mu2e/app/users/mmackenz/Yale/main
+     build  al9-prof-e29-p083    08/12/25 17:35:27
    ******************************************************************
-Conditions file: /scratch/workspace/GitHubPRTests/mu2e-offline-build-test/Offline/ConditionsService/data/conditions_01.txt
+Conditions file: /exp/mu2e/app/users/mmackenz/Yale/main/Offline/ConditionsService/data/conditions_01.txt
 Conditions lines: 38  hash: 8098310628555253397
 DbService  MDC2020_best v1_3   mu2e_conditions_prd
 DbService  textFiles: 
-GlobalConstants file: /scratch/workspace/GitHubPRTests/mu2e-offline-build-test/Offline/GlobalConstantsService/data/globalConstants_01.txt
+GlobalConstants file: /exp/mu2e/app/users/mmackenz/Yale/main/Offline/GlobalConstantsService/data/globalConstants_01.txt
 GlobalConstants lines: 165  hash: 10185786924093877558
 BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing ( 0x1 : Inactive )
 BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing ( 0x1 : Inactive )
@@ -15,16 +15,16 @@ BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing (
 BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing ( 0x1 : Inactive )
 BkgANNSHU weights Offline/Mu2eKinKal/data/TrainBkgTrigger.dat cut 0.2 freezing ( 0x1 : Inactive )
 DeltaFinderAlg created
-13-Aug-2025 11:03:55 CDT  Initiating request to open input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
-13-Aug-2025 11:03:55 CDT  Opened input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
+13-Aug-2025 11:49:30 CDT  Initiating request to open input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
+13-Aug-2025 11:49:31 CDT  Opened input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
 tprHelixDeIpaHSFilter NO HELIX CUT HAS BEEN SET FOR THE HELICES WITH NEGATIVE HELICITY. IF THAT'S NOT THE DESIRED BEHAVIOUR REVIEW YOUR CONFIGUREATION!
 tprHelixDeIpaPhiScaledHSFilter NO HELIX CUT HAS BEEN SET FOR THE HELICES WITH NEGATIVE HELICITY. IF THAT'S NOT THE DESIRED BEHAVIOUR REVIEW YOUR CONFIGUREATION!
-Geometry file: /scratch/workspace/GitHubPRTests/mu2e-offline-build-test/Offline/Mu2eG4/geom/geom_common.txt
-Geometry lines: 21767  hash: 6156955001906094491
-BField file: /scratch/workspace/GitHubPRTests/mu2e-offline-build-test/Offline/Mu2eG4/geom/bfgeom_reco_v01.txt
+Geometry file: /exp/mu2e/app/users/mmackenz/Yale/main/Offline/Mu2eG4/geom/geom_common.txt
+Geometry lines: 21763  hash: 5785303828219236850
+BField file: /exp/mu2e/app/users/mmackenz/Yale/main/Offline/Mu2eG4/geom/bfgeom_reco_v01.txt
 BField lines: 98  hash: 3243269116804334601
-Begin processing the 1st record. run: 1202 subRun: 0 event: 1 at 13-Aug-2025 11:03:55 CDT
-DbReader::fillValCache took 0.253972 s
+Begin processing the 1st record. run: 1202 subRun: 0 event: 1 at 13-Aug-2025 11:50:09 CDT
+DbReader::fillValCache took 0.317989 s
 DbEngine confirmed purpose and version:
 MDC2020_best 1/3/-1
 DbEngine IoV summary
@@ -49,180 +49,181 @@ DbEngine IoV summary
              CRVSiPM       6
            CRVPhoton       6
              CRVTime       6
-DbEngine inclusive beginJob time was 0.254122 s
-Begin processing the 2nd record. run: 1202 subRun: 0 event: 2 at 13-Aug-2025 11:03:56 CDT
-Begin processing the 3rd record. run: 1202 subRun: 0 event: 3 at 13-Aug-2025 11:03:56 CDT
-Begin processing the 5th record. run: 1202 subRun: 0 event: 5 at 13-Aug-2025 11:03:56 CDT
-Begin processing the 9th record. run: 1202 subRun: 0 event: 9 at 13-Aug-2025 11:03:56 CDT
-Begin processing the 17th record. run: 1202 subRun: 0 event: 17 at 13-Aug-2025 11:03:57 CDT
-Begin processing the 33rd record. run: 1202 subRun: 0 event: 33 at 13-Aug-2025 11:03:57 CDT
-Begin processing the 65th record. run: 1202 subRun: 0 event: 65 at 13-Aug-2025 11:03:58 CDT
-Begin processing the 129th record. run: 1202 subRun: 0 event: 129 at 13-Aug-2025 11:03:58 CDT
-Begin processing the 257th record. run: 1202 subRun: 0 event: 257 at 13-Aug-2025 11:04:01 CDT
-Begin processing the 513th record. run: 1202 subRun: 0 event: 513 at 13-Aug-2025 11:04:06 CDT
-Begin processing the 1025th record. run: 1202 subRun: 0 event: 1025 at 13-Aug-2025 11:04:17 CDT
-Begin processing the 2049th record. run: 1202 subRun: 0 event: 2049 at 13-Aug-2025 11:04:37 CDT
-Begin processing the 4097th record. run: 1202 subRun: 1 event: 97 at 13-Aug-2025 11:05:15 CDT
-Begin processing the 8193rd record. run: 1202 subRun: 2 event: 193 at 13-Aug-2025 11:06:34 CDT
-13-Aug-2025 11:07:09 CDT  Closed input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
-13-Aug-2025 11:07:09 CDT  Initiating request to open input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
-13-Aug-2025 11:07:09 CDT  Opened input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
-%MSG-w GEOM:  BeginRun 13-Aug-2025 11:07:09 CDT run: 1202
+DbEngine inclusive beginJob time was 0.318315 s
+Begin processing the 2nd record. run: 1202 subRun: 0 event: 2 at 13-Aug-2025 11:50:10 CDT
+Begin processing the 3rd record. run: 1202 subRun: 0 event: 3 at 13-Aug-2025 11:50:10 CDT
+Begin processing the 5th record. run: 1202 subRun: 0 event: 5 at 13-Aug-2025 11:50:10 CDT
+Begin processing the 9th record. run: 1202 subRun: 0 event: 9 at 13-Aug-2025 11:50:11 CDT
+Begin processing the 17th record. run: 1202 subRun: 0 event: 17 at 13-Aug-2025 11:50:11 CDT
+Begin processing the 33rd record. run: 1202 subRun: 0 event: 33 at 13-Aug-2025 11:50:11 CDT
+Begin processing the 65th record. run: 1202 subRun: 0 event: 65 at 13-Aug-2025 11:50:12 CDT
+Begin processing the 129th record. run: 1202 subRun: 0 event: 129 at 13-Aug-2025 11:50:13 CDT
+Begin processing the 257th record. run: 1202 subRun: 0 event: 257 at 13-Aug-2025 11:50:15 CDT
+Begin processing the 513th record. run: 1202 subRun: 0 event: 513 at 13-Aug-2025 11:50:21 CDT
+Begin processing the 1025th record. run: 1202 subRun: 0 event: 1025 at 13-Aug-2025 11:50:32 CDT
+Begin processing the 2049th record. run: 1202 subRun: 0 event: 2049 at 13-Aug-2025 11:50:53 CDT
+Begin processing the 4097th record. run: 1202 subRun: 1 event: 97 at 13-Aug-2025 11:51:33 CDT
+Begin processing the 8193rd record. run: 1202 subRun: 2 event: 193 at 13-Aug-2025 11:53:00 CDT
+13-Aug-2025 11:53:38 CDT  Closed input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1a.art"
+13-Aug-2025 11:53:38 CDT  Initiating request to open input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
+13-Aug-2025 11:53:38 CDT  Opened input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
+%MSG-w GEOM:  BeginRun 13-Aug-2025 11:53:38 CDT run: 1202
 This test version does not change geometry on run boundaries.
 %MSG
 This test version does not change geometry on run boundaries.
-Begin processing the 16385th record. run: 1202 subRun: 4 event: 385 at 13-Aug-2025 11:09:10 CDT
-13-Aug-2025 11:10:19 CDT  Closed input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
+Begin processing the 16385th record. run: 1202 subRun: 4 event: 385 at 13-Aug-2025 11:55:50 CDT
+13-Aug-2025 11:57:05 CDT  Closed input file "/cvmfs/mu2e.opensciencegrid.org/DataFiles/Validation/skim_NoPrimary1BB_1b.art"
 
 =======================================================================================================================================================================
 TimeTracker printout (sec)                                                               Min           Avg           Max         Median          RMS         nEvts   
 =======================================================================================================================================================================
-Full event                                                                           0.000965446    0.0190696     0.891117      0.0104635     0.0253053      20000   
+Full event                                                                           0.00110076     0.0206235     0.969854      0.0115098     0.0266309      20000   
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-source:RootInput(read)                                                               6.1991e-05    9.4001e-05    0.000548867   8.8102e-05    2.74276e-05     20000   
-caloHitRec_N0Source:processCFOData:EventHeaderFromCFOFragment                         1.002e-05    1.14112e-05   0.000271268    1.113e-05    2.42186e-06     20000   
-caloHitRec_N0Source:caloHitRecN0SourcePS:PrescaleEvent                                7.72e-06     9.37376e-06   0.000424844    8.991e-06    6.70263e-06     20000   
-minBias_CDCount:minBiasCDCountPS:PrescaleEvent                                        1.67e-06     2.16821e-06   1.4361e-05     2.13e-06     3.55225e-07     20000   
-minBias_SDCount:minBiasSDCountPS:PrescaleEvent                                        1.46e-06     1.80353e-06    8.991e-06     1.771e-06    2.92219e-07     20000   
-cstCosmicTrackSeed:cstCosmicTrackSeedPS:PrescaleEvent                                 1.49e-06     1.82006e-06   5.3871e-05     1.78e-06     5.00984e-07     20000   
-cstTimeCluster:cstTimeClusterPS:PrescaleEvent                                         1.39e-06     1.66331e-06   1.2381e-05     1.64e-06     2.71891e-07     20000   
-caloFast_RMC:caloFastRMCPS:PrescaleEvent                                              1.42e-06     1.69295e-06    1.466e-05     1.66e-06     3.39228e-07     20000   
-caloFast_RMC:CaloHitMakerFast:CaloHitMakerFast                                       7.3012e-05    0.000457638   0.00239716    0.000381846   0.000281771     20000   
-caloFast_RMC:CaloClusterFast:CaloClusterFast                                          9.32e-06     5.23627e-05   0.000258537   4.40265e-05   3.14567e-05     20000   
-caloFast_RMC:caloFastRMCFilter:CaloClusterCounterFilter                               6.33e-06     7.34172e-06   6.0902e-05     7.27e-06     7.26377e-07     20000   
-caloFast_cosmic:caloFastCosmicPS:PrescaleEvent                                        2.42e-06     3.07388e-06    1.798e-05     3.05e-06     3.70627e-07     20000   
-caloFast_cosmic:caloFastCosmicFilter:CaloCosmicCalib                                  4.42e-06     5.27066e-06   2.0601e-05     5.22e-06     5.28541e-07     20000   
-caloFast_MVANNCE:caloFastMVANNCEPS:PrescaleEvent                                      1.68e-06     1.99715e-06   1.7791e-05     1.97e-06     3.04909e-07     20000   
-caloFast_MVANNCE:caloFastMVANNCEFilter:FilterEcalNNTrigger                            5.051e-06    6.61472e-06   4.7612e-05     6.64e-06     1.0659e-06      20000   
-caloFast_photon:caloFastPhotonPS:PrescaleEvent                                        1.701e-06    1.98855e-06    9.39e-06      1.96e-06     2.70173e-07     20000   
-caloFast_photon:caloFastPhotonFilter:CaloLikelihood                                   4.89e-06     6.51002e-06   4.4782e-05     5.86e-06     1.62471e-06     20000   
-aprHelix:aprLowPStopTargPS:PrescaleEvent                                              1.75e-06     2.21655e-06   6.6053e-05     2.19e-06     5.45904e-07     20000   
-aprHelix:TTmakeSD:StrawDigisFromArtdaqFragments                                       7.91e-06     8.91076e-06   5.9961e-05     8.79e-06     7.70858e-07     20000   
-aprHelix:TTmakeSH:StrawHitReco                                                       3.2811e-05    0.000380638    0.882717     0.000284698   0.00624257      20000   
-aprHelix:TTmakePH:CombineStrawHits                                                    8.53e-06     6.97782e-05   0.000552747   5.4712e-05    5.2248e-05      20000   
-aprHelix:TTflagPH:DeltaFinder                                                        7.8933e-05    0.000375297   0.00459977    0.000271827   0.000328764     20000   
-aprHelix:TTTZClusterFinder:TZClusterFinder                                           1.2721e-05    8.55456e-05   0.000713155   6.0542e-05    7.59142e-05     20000   
-aprHelix:aprHelixTCFilter:TimeClusterFilter                                           9.18e-06     1.18483e-05   0.000220176   1.1711e-05    1.93572e-06     20000   
-aprHelix:TTAprHelixFinder:AgnosticHelixFinder                                         1.002e-05    0.000245211    0.0113628    9.30085e-05   0.000416927     16392   
-aprHelix:TTAprHelixMerger:MergeHelices                                                1.043e-05    1.2741e-05    0.000212786   1.2241e-05    3.00031e-06     16392   
-aprHelix:aprHelixHSFilter:HelixFilter                                                 5.88e-06     7.1742e-06    3.1921e-05     6.82e-06     1.12641e-06     16392   
-apr_lowP_multiHelix:aprLowPMultiHelixPS:PrescaleEvent                                  2.3e-06     2.98852e-06   0.000114523    2.95e-06     8.85594e-07     20000   
-apr_lowP_multiHelix:aprLowPMultiHelixTCFilter:TimeClusterFilter                       7.281e-06    9.46373e-06   6.3963e-05    9.3855e-06    1.01935e-06     20000   
-apr_lowP_multiHelix:aprLowPMultiHelixHSFilter:HelixFilter                             5.08e-06     6.18013e-06   0.000116724    5.92e-06     1.2252e-06      16392   
-apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkPS:PrescaleEvent                  1.72e-06     2.17098e-06    1.691e-05     2.14e-06     3.39733e-07     20000   
-apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkTCFilter:TimeClusterFilter        6.85e-06     8.22294e-06   2.0991e-05     8.12e-06     7.67256e-07     20000   
-apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkHSFilter:HelixFilter              4.73e-06     5.6474e-06    1.7301e-05     5.46e-06     6.95941e-07     16392   
-apr_lowP_stopTarg:aprLowPStopTargTCFilter:TimeClusterFilter                           6.25e-06     7.50484e-06   2.1751e-05     7.42e-06     6.81723e-07     20000   
-apr_lowP_stopTarg:aprLowPStopTargHSFilter:HelixFilter                                 4.62e-06     5.41478e-06   2.0371e-05     5.231e-06    6.66517e-07     16392   
-apr_ue_highP:aprUeHighPPS:PrescaleEvent                                               1.68e-06     2.08452e-06    8.78e-06      2.04e-06     3.15155e-07     20000   
-apr_ue_highP:aprUeHighPTCFilter:TimeClusterFilter                                     5.891e-06    7.40313e-06    1.773e-05     7.24e-06     8.62252e-07     20000   
-apr_ue_highP:aprUeHighPHSFilter:HelixFilter                                           4.57e-06     5.43287e-06   1.7001e-05     5.18e-06     8.89539e-07     16392   
-apr_highP:aprHighPPS:PrescaleEvent                                                    1.63e-06     2.01265e-06   1.8521e-05     1.98e-06     3.25914e-07     20000   
-apr_highP:aprHighPTCFilter:TimeClusterFilter                                            6e-06      7.24471e-06   2.2141e-05     7.09e-06     8.1014e-07      20000   
-apr_highP:aprHighPHSFilter:HelixFilter                                                4.45e-06     5.27212e-06    1.551e-05     5.05e-06     7.70392e-07     16392   
-apr_highP_stopTarg:aprHighPStopTargPS:PrescaleEvent                                   1.66e-06     1.98185e-06    8.27e-06      1.95e-06     2.65835e-07     20000   
-apr_highP_stopTarg:aprHighPStopTargTCFilter:TimeClusterFilter                         5.961e-06    7.11367e-06   1.6951e-05     6.99e-06     7.0013e-07      20000   
-apr_highP_stopTarg:aprHighPStopTargHSFilter:HelixFilter                               4.51e-06     5.23964e-06   1.3811e-05     5.05e-06     6.6401e-07      16392   
-cprHelixUe:cprHelixUePS:PrescaleEvent                                                 1.66e-06     2.0043e-06    7.4104e-05     1.98e-06     5.7781e-07      20000   
-cprHelixUe:TTCalTimePeakFinderUe:CalTimePeakFinder                                     7.9e-06     1.13533e-05   0.000155924    9.201e-06    7.30714e-06     20000   
-cprHelixUe:cprHelixUeTCFilter:TimeClusterFilter                                        7.7e-06     8.77741e-06    2.012e-05     8.62e-06     7.10991e-07     20000   
-cprHelixDe:cprHelixDePS:PrescaleEvent                                                 1.71e-06     2.10381e-06    9.841e-06     2.06e-06     3.05145e-07     20000   
-cprHelixDe:TTCalTimePeakFinder:CalTimePeakFinder                                      6.42e-06     9.57919e-06   0.000154205    7.37e-06     7.31328e-06     20000   
-cprHelixDe:cprHelixDeTCFilter:TimeClusterFilter                                       6.771e-06    7.81487e-06   3.3881e-05     7.581e-06    8.58615e-07     20000   
-cprDe_lowP_stopTarg:cprDeLowPStopTargPS:PrescaleEvent                                 1.66e-06     2.03258e-06    9.161e-06     1.97e-06     3.45201e-07     20000   
-cprDe_lowP_stopTarg:cprDeLowPStopTargTCFilter:TimeClusterFilter                       6.25e-06     7.44565e-06   1.7641e-05     7.22e-06     8.21858e-07     20000   
-cprDe_highP:cprDeHighPPS:PrescaleEvent                                                1.58e-06     1.89376e-06    8.85e-06      1.86e-06     2.98558e-07     20000   
-cprDe_highP:cprDeHighPTCFilter:TimeClusterFilter                                      5.98e-06     6.89417e-06   1.6991e-05     6.751e-06    6.85181e-07     20000   
-cprDe_highP_stopTarg:cprDeHighPStopTargPS:PrescaleEvent                               1.64e-06     1.93059e-06    9.45e-06       1.9e-06     2.72763e-07     20000   
-cprDe_highP_stopTarg:cprDeHighPStopTargTCFilter:TimeClusterFilter                      5.8e-06     6.71151e-06    1.67e-05      6.601e-06    5.97134e-07     20000   
-tprHelixUe:tprHelixUePS:PrescaleEvent                                                 1.73e-06     2.0785e-06     1.915e-05     2.06e-06     2.80205e-07     20000   
-tprHelixUe:TTtimeClusterFinderUe:TimeClusterFinder                                   2.8081e-05    0.00178686     0.0299779    0.00106239    0.00223472      20000   
-tprHelixUe:tprHelixUeTCFilter:TimeClusterFilter                                       7.791e-06    1.08283e-05    2.038e-05     1.09e-05     1.10711e-06     20000   
-tprHelixUe:TThelixFinderUe:RobustHelixFinder                                          9.421e-06    0.000596341     0.0157      0.000318799   0.000896441     19888   
-tprHelixUe:TTHelixMergerUe:MergeHelices                                                9.5e-06     1.43717e-05   0.000194365    1.33e-05     3.94041e-06     19888   
-tprHelixUe:tprHelixUeHSFilter:HelixFilter                                              5.3e-06     7.96226e-06   0.000123974    7.15e-06     1.99783e-06     19888   
-tprHelixDe:tprHelixDePS:PrescaleEvent                                                  1.7e-06     2.73381e-06    1.058e-05     2.74e-06     3.70669e-07     20000   
-tprHelixDe:TTtimeClusterFinder:TimeClusterFinder                                     2.5931e-05    0.00171101     0.0275776    0.00100512    0.00218708      20000   
-tprHelixDe:tprHelixDeTCFilter:TimeClusterFilter                                       7.25e-06     1.1114e-05    0.000179485    1.116e-05    1.68077e-06     20000   
-tprHelixDe:TThelixFinder:RobustHelixFinder                                             7.7e-06     0.00064259     0.0738858    0.000330108   0.00111358      19893   
-tprHelixDe:TTHelixMergerDe:MergeHelices                                               8.45e-06     1.36476e-05   0.000190995    1.258e-05    3.93577e-06     19893   
-tprHelixDe:tprHelixDeHSFilter:HelixFilter                                             5.05e-06     7.71381e-06   4.3811e-05     6.89e-06     1.87831e-06     19893   
-tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledPS:PrescaleEvent                       1.79e-06     2.74305e-06    1.312e-05     2.75e-06     3.64065e-07     20000   
-tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTCFilter:TimeClusterFilter             6.92e-06     1.06675e-05   0.000200326    1.063e-05    1.88328e-06     20000   
-tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledHSFilter:HelixFilter                   4.58e-06     6.00943e-06    2.413e-05     5.64e-06     1.03095e-06     19893   
-tprHelixDe_ipa:tprHelixDeIpaPS:PrescaleEvent                                          1.65e-06     2.15532e-06    7.97e-06      2.13e-06     2.59958e-07     20000   
-tprHelixDe_ipa:tprHelixDeIpaTCFilter:TimeClusterFilter                                6.46e-06     8.31003e-06   0.000191865    8.151e-06    2.98064e-06     20000   
-tprHelixDe_ipa:tprHelixDeIpaHSFilter:HelixFilter                                      4.39e-06     5.51655e-06   2.6171e-05      5.2e-06     8.54294e-07     19893   
-tprDe_lowP_stopTarg:tprDeLowPStopTargPS:PrescaleEvent                                 1.67e-06     2.0584e-06     7.95e-06      2.03e-06     2.54444e-07     20000   
-tprDe_lowP_stopTarg:tprDeLowPStopTargTCFilter:TimeClusterFilter                       6.69e-06     8.16407e-06   0.000197676    7.991e-06    3.11545e-06     20000   
-tprDe_lowP_stopTarg:tprDeLowPStopTargHSFilter:HelixFilter                             4.78e-06     6.12034e-06   2.2541e-05     5.551e-06    1.19824e-06     19937   
-tprDe_highP:tprDeHighPPS:PrescaleEvent                                                1.59e-06     2.04854e-06   0.000103484    1.93e-06     8.28822e-07     20000   
-tprDe_highP:tprDeHighPTCFilter:TimeClusterFilter                                      6.82e-06     8.40647e-06   0.000201886    8.01e-06     1.90205e-06     20000   
-tprDe_highP:tprDeHighPHSFilter:HelixFilter                                            4.42e-06     5.92962e-06   2.5261e-05     5.16e-06     1.68251e-06     19893   
-tprDe_highP_stopTarg:tprDeHighPStopTargPS:PrescaleEvent                               1.68e-06     2.05423e-06    8.01e-06      2.01e-06     2.7188e-07      20000   
-tprDe_highP_stopTarg:tprDeHighPStopTargTCFilter:TimeClusterFilter                      6.5e-06     7.90792e-06   0.000193245    7.66e-06     2.7401e-06      20000   
-tprDe_highP_stopTarg:tprDeHighPStopTargHSFilter:HelixFilter                           4.59e-06     5.85058e-06   0.000117944    5.27e-06     1.47305e-06     19893   
-mprDe_highP_stopTarg:mprDeHighPStopTargPS:PrescaleEvent                               1.62e-06     1.91176e-06    8.071e-06     1.88e-06     2.4615e-07      20000   
-mprDe_highP_stopTarg:mprDeHighPStopTargTCFilter:TimeClusterFilter                     6.711e-06    9.33444e-06   0.000214075    7.971e-06    1.34333e-05     20000   
-mprDe_highP_stopTarg:TTRobustMultiHelixFinder:RobustMultiHelixFinder                  1.653e-05    0.00396895     0.197896     0.00143137    0.00854076      19893   
-mprDe_highP_stopTarg:TTMprHelixMergerDe:MergeHelices                                  1.226e-05    0.00014346    0.00519494    4.0421e-05    0.000295352     19893   
-mprDe_highP_stopTarg:mprDeHighPStopTargHSFilter:HelixFilter                           5.34e-06     1.89631e-05   9.9244e-05     1.539e-05    1.27025e-05     19893   
-mprDe_highP_stopTarg:TTMprKSFDe:LoopHelixFit                                         0.000138515    0.0116479     0.0973436    0.00822462     0.0107456      12558   
-mprDe_highP_stopTarg:mprDeHighPStopTargKSFilter:KalSeedFilter                         7.55e-06     1.68883e-05   6.0432e-05    1.5461e-05    6.42088e-06     12558   
-[art]:TriggerResults:TriggerResultInserter                                            3.51e-06     4.14704e-06   1.8451e-05     4.11e-06     4.11763e-07     20000   
-cprHelixUe:TTCalHelixFinderUe:CalHelixFinder                                         2.4451e-05    0.000174065   0.00273207    0.00011492    0.000178201     1738    
-cprHelixUe:TTCalHelixMergerUe:MergeHelices                                            1.01e-05     1.20323e-05   2.7321e-05    1.1761e-05    1.27146e-06     1738    
-cprHelixUe:cprHelixUeHSFilter:HelixFilter                                             5.81e-06     6.91926e-06   1.3641e-05    6.6305e-06    9.84399e-07     1738    
-cprHelixDe:TTCalHelixFinderDe:CalHelixFinder                                          2.075e-05    0.000188834   0.00273732    0.000121433   0.000199107     1794    
-cprHelixDe:TTCalHelixMergerDe:MergeHelices                                            9.63e-06     1.19128e-05   2.3091e-05    1.1501e-05    1.57703e-06     1794    
-cprHelixDe:cprHelixDeHSFilter:HelixFilter                                             5.451e-06    6.84442e-06   1.6351e-05     6.41e-06     1.22444e-06     1794    
-cprDe_lowP_stopTarg:cprDeLowPStopTargHSFilter:HelixFilter                             5.25e-06     6.23821e-06   1.6801e-05     5.911e-06    9.14053e-07     1794    
-cprDe_highP:cprDeHighPHSFilter:HelixFilter                                            4.64e-06     5.70255e-06    1.239e-05     5.351e-06    9.84678e-07     1794    
-cprDe_highP_stopTarg:cprDeHighPStopTargHSFilter:HelixFilter                           4.81e-06     5.72696e-06    1.856e-05     5.45e-06     8.90322e-07     1794    
-tprHelixDe:tprHelixDeTriggerInfoMerger:MergeTriggerInfo                               1.274e-05    1.56135e-05   0.000200666    1.517e-05    5.79118e-06     1446    
-tprDe_lowP_stopTarg:TTKSFDe:LoopHelixFit                                             0.000154205   0.00176235     0.0107022    0.00150059     0.0011811      1774    
-tprDe_lowP_stopTarg:tprDeLowPStopTargKSFilter:KalSeedFilter                            7.6e-06     1.14577e-05    2.114e-05    1.17255e-05   2.40255e-06     1774    
-mprDe_highP_stopTarg:mprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo            1.5751e-05    1.88261e-05   3.3531e-05    1.8375e-05    1.8771e-06       318    
-aprHelix:aprHelixTriggerInfoMerger:MergeTriggerInfo                                  1.4121e-05    1.62962e-05   2.6141e-05     1.607e-05    1.20937e-06     1305    
-apr_lowP_stopTarg:TTAprKSF:LoopHelixFit                                              0.000164245   0.00112318    0.00737372    0.00101093    0.000889784      564    
-apr_lowP_stopTarg:aprLowPStopTargKSFilter:KalSeedFilter                               4.66e-06     1.07915e-05    1.979e-05     9.991e-06    2.48122e-06      593    
-apr_lowP_stopTarg:aprLowPStopTargTriggerInfoMerger:MergeTriggerInfo                  1.3501e-05    1.6798e-05    2.2871e-05     1.677e-05    1.12132e-06      133    
-tprDe_lowP_stopTarg:tprDeLowPStopTargTriggerInfoMerger:MergeTriggerInfo              1.4781e-05    1.65813e-05    2.226e-05    1.6341e-05    1.23606e-06      141    
-tprHelixUe:tprHelixUeTriggerInfoMerger:MergeTriggerInfo                               1.278e-05    1.60785e-05   3.3871e-05    1.5861e-05    1.51258e-06     1940    
-apr_ue_highP:TTAprUeKSF:LoopHelixFit                                                 0.000143483   0.000786198   0.00438542    0.000554584   0.000672721      321    
-apr_ue_highP:aprUeHighPKSFilter:KalSeedFilter                                         6.98e-06     9.49869e-06    1.506e-05     9.141e-06    1.55357e-06      321    
-apr_highP:TTAprKSF:LoopHelixFit                                                      0.000135587   0.000915884   0.00402125    0.000720955   0.000719107      135    
-apr_highP:aprHighPKSFilter:KalSeedFilter                                              4.79e-06     7.1012e-06     1.363e-05     6.13e-06     1.96875e-06      321    
-tprDe_highP:tprDeHighPKSFilter:KalSeedFilter                                           4.9e-06     7.14868e-06   1.6721e-05     6.04e-06     2.03345e-06     1125    
-tprDe_highP_stopTarg:tprDeHighPStopTargKSFilter:KalSeedFilter                         4.34e-06     6.23155e-06   1.4381e-05     5.415e-06    1.45742e-06      712    
-tprHelixDe_ipa:tprHelixDeIpaTriggerInfoMerger:MergeTriggerInfo                        9.93e-06     1.29578e-05    2.292e-05    1.2535e-05    1.58613e-06      552    
-tprDe_highP:TTKSFDe:LoopHelixFit                                                     0.000165295   0.00145801     0.0060058    0.00117412    0.00112332       121    
-cprHelixDe:cprHelixDeTriggerInfoMerger:MergeTriggerInfo                              1.4161e-05    1.61262e-05   2.1281e-05    1.58705e-05   1.32536e-06      82     
-cprDe_highP:TTCalSeedFitDe:LoopHelixFit                                              0.000219855   0.000671647   0.00143016    0.000408502   0.000466725       5     
-cprDe_highP:cprDeHighPKSFilter:KalSeedFilter                                          5.31e-06     7.32524e-06    1.328e-05     6.265e-06    1.91416e-06      46     
-tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTriggerInfoMerger:MergeTriggerInfo     1.142e-05    1.37704e-05   2.0041e-05     1.405e-05    1.61436e-06      147    
-cprDe_lowP_stopTarg:TTCalSeedFitDe:LoopHelixFit                                      0.000153265   0.000952205   0.00326484    0.000950147   0.000695406      78     
-cprDe_lowP_stopTarg:cprDeLowPStopTargKSFilter:KalSeedFilter                           8.07e-06     1.11973e-05    1.806e-05    1.0616e-05    2.06692e-06      78     
-apr_highP_stopTarg:aprHighPStopTargKSFilter:KalSeedFilter                             4.76e-06     5.85766e-06    9.54e-06      5.501e-06    1.02506e-06      79     
-tprDe_lowP_stopTarg:TThelixFinder:RobustHelixFinder                                   8.72e-06     2.60076e-05   0.000205836    1.511e-05    3.09837e-05      44     
-tprDe_lowP_stopTarg:TTHelixMergerDe:MergeHelices                                      9.38e-06     1.18409e-05    1.338e-05    1.1885e-05    9.52146e-07      44     
-apr_lowP_multiHelix:TTAprKSF:LoopHelixFit                                            0.000334308   0.00233086    0.00743732    0.00175401    0.00174354       29     
-apr_lowP_multiHelix:aprLowPMultiHelixKSFilter:KalSeedFilter                           9.11e-06     1.23748e-05   1.7711e-05     1.237e-05    2.85209e-06      29     
-apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkKSFilter:KalSeedFilter            5.72e-06     6.29867e-06    6.72e-06     6.3955e-06    3.21359e-07       6     
-cprDe_lowP_stopTarg:cprDeLowPStopTargTriggerInfoMerger:MergeTriggerInfo              1.5971e-05    1.69866e-05   2.0771e-05    1.6791e-05    1.06013e-06      20     
-cprDe_highP_stopTarg:cprDeHighPStopTargKSFilter:KalSeedFilter                         5.34e-06     7.10655e-06    8.931e-06      7.4e-06     1.26294e-06      20     
-apr_lowP_multiHelix:aprLowPMultiHelixTriggerInfoMerger:MergeTriggerInfo               1.715e-05    1.76503e-05    1.825e-05    1.7551e-05    4.54533e-07       3     
-tprDe_highP:tprDeHighPTriggerInfoMerger:MergeTriggerInfo                             1.3331e-05    1.50424e-05    1.747e-05     1.496e-05    1.42607e-06       5     
-apr_highP:aprHighPTriggerInfoMerger:MergeTriggerInfo                                 1.5771e-05    1.62405e-05    1.671e-05    1.62405e-05    4.695e-07        2     
-cprDe_highP:cprDeHighPTriggerInfoMerger:MergeTriggerInfo                              1.498e-05     1.498e-05     1.498e-05     1.498e-05         0            1     
-cprDe_highP_stopTarg:cprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo             1.403e-05     1.403e-05     1.403e-05     1.403e-05         0            1     
-apr_highP_stopTarg:aprHighPStopTargTriggerInfoMerger:MergeTriggerInfo                 1.434e-05     1.434e-05     1.434e-05     1.434e-05         0            1     
-tprDe_highP_stopTarg:tprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo            1.3711e-05    1.3711e-05    1.3711e-05    1.3711e-05         0            1     
+source:RootInput(read)                                                               6.8922e-05    0.000156641    0.0282126    0.000112966   0.000299152     20000   
+caloHitRec_N0Source:processCFOData:EventHeaderFromCFOFragment                         1.058e-05    1.51619e-05   0.000356612   1.3056e-05    7.29878e-06     20000   
+caloHitRec_N0Source:caloHitRecN0SourcePS:PrescaleEvent                                8.486e-06    1.52672e-05   0.00223975    1.1573e-05    4.34002e-05     20000   
+minBias_CDCount:minBiasCDCountPS:PrescaleEvent                                        1.863e-06    2.63864e-06   6.7809e-05     2.336e-06    1.40096e-06     20000   
+minBias_SDCount:minBiasSDCountPS:PrescaleEvent                                        1.533e-06    2.20814e-06   0.00010517     2.014e-06    1.44977e-06     20000   
+cstCosmicTrackSeed:cstCosmicTrackSeedPS:PrescaleEvent                                 1.553e-06    2.32716e-06   0.000195654    2.034e-06    1.85998e-06     20000   
+cstTimeCluster:cstTimeClusterPS:PrescaleEvent                                         1.433e-06    2.09048e-06   0.000203398    1.763e-06    2.32484e-06     20000   
+caloFast_RMC:caloFastRMCPS:PrescaleEvent                                              1.562e-06    2.21008e-06   5.0817e-05     1.934e-06    1.23484e-06     20000   
+caloFast_RMC:CaloHitMakerFast:CaloHitMakerFast                                       9.1204e-05    0.000613986    0.0301656    0.000479381   0.000570274     20000   
+caloFast_RMC:CaloClusterFast:CaloClusterFast                                          9.699e-06    6.57611e-05   0.000603424   5.50305e-05   4.17739e-05     20000   
+caloFast_RMC:caloFastRMCFilter:CaloClusterCounterFilter                               6.843e-06    9.67116e-06   0.000321704    8.506e-06    4.82314e-06     20000   
+caloFast_cosmic:caloFastCosmicPS:PrescaleEvent                                        2.535e-06    3.92226e-06   0.000191686    3.526e-06    2.61361e-06     20000   
+caloFast_cosmic:caloFastCosmicFilter:CaloCosmicCalib                                  4.649e-06    6.44535e-06   0.000220903    5.731e-06    2.83257e-06     20000   
+caloFast_MVANNCE:caloFastMVANNCEPS:PrescaleEvent                                      1.764e-06    2.53231e-06   3.4076e-05     2.244e-06    1.30264e-06     20000   
+caloFast_MVANNCE:caloFastMVANNCEFilter:FilterEcalNNTrigger                            5.03e-06     8.83124e-06   0.000211585    7.865e-06    4.22606e-06     20000   
+caloFast_photon:caloFastPhotonPS:PrescaleEvent                                        1.673e-06    2.37069e-06   0.000190685    2.065e-06    1.76391e-06     20000   
+caloFast_photon:caloFastPhotonFilter:CaloLikelihood                                   5.151e-06    9.33935e-06   0.00121009     6.733e-06    1.21496e-05     20000   
+aprHelix:aprLowPStopTargPS:PrescaleEvent                                              1.823e-06    2.75815e-06   0.000329911    2.395e-06    2.69766e-06     20000   
+aprHelix:TTmakeSD:StrawDigisFromArtdaqFragments                                       8.316e-06    1.15574e-05   0.000214149    9.919e-06    4.94238e-06     20000   
+aprHelix:TTmakeSH:StrawHitReco                                                       4.0246e-05    0.000575062    0.954003     0.000452144   0.00674998      20000   
+aprHelix:TTmakePH:CombineStrawHits                                                    9.578e-06    7.8433e-05    0.000943845   6.1117e-05    6.01351e-05     20000   
+aprHelix:TTflagPH:DeltaFinder                                                        8.4992e-05    0.000526612    0.0135635    0.000401492   0.000431466     20000   
+aprHelix:TTTZClusterFinder:TZClusterFinder                                           1.2525e-05    9.50073e-05   0.000790321    6.842e-05    8.19911e-05     20000   
+aprHelix:aprHelixTCFilter:TimeClusterFilter                                           9.97e-06     1.43862e-05   0.000204291   1.3044e-05    4.81854e-06     20000   
+aprHelix:TTAprHelixFinder:AgnosticHelixFinder                                        1.0741e-05    0.000262002    0.0119046    0.000101855   0.000440689     16299   
+aprHelix:TTAprHelixMerger:MergeHelices                                               1.1612e-05    1.59196e-05   0.000378774   1.4288e-05    6.48831e-06     16299   
+aprHelix:aprHelixHSFilter:HelixFilter                                                 5.991e-06    8.45161e-06   0.000205333    7.514e-06    3.94032e-06     16299   
+apr_lowP_multiHelix:aprLowPMultiHelixPS:PrescaleEvent                                 2.375e-06    3.7972e-06    0.00155021     3.317e-06    1.1452e-05      20000   
+apr_lowP_multiHelix:aprLowPMultiHelixTCFilter:TimeClusterFilter                       7.494e-06    1.09133e-05   0.000387401   1.0109e-05    5.18592e-06     20000   
+apr_lowP_multiHelix:aprLowPMultiHelixHSFilter:HelixFilter                             5.361e-06    7.40996e-06   6.7639e-05     6.633e-06    2.49022e-06     16299   
+apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkPS:PrescaleEvent                  1.753e-06    2.7161e-06    0.000204561    2.404e-06    1.97433e-06     20000   
+apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkTCFilter:TimeClusterFilter        7.074e-06    9.45438e-06   0.000225431    8.576e-06    3.94731e-06     20000   
+apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkHSFilter:HelixFilter              4.94e-06     6.74122e-06   0.000107655    5.962e-06    2.65946e-06     16299   
+apr_lowP_stopTarg:aprLowPStopTargTCFilter:TimeClusterFilter                           6.473e-06    8.6505e-06    4.9705e-05     7.784e-06    2.88778e-06     20000   
+apr_lowP_stopTarg:aprLowPStopTargHSFilter:HelixFilter                                  4.8e-06     6.68891e-06   0.000210141    5.952e-06    3.31641e-06     16299   
+apr_ue_highP:aprUeHighPPS:PrescaleEvent                                               1.773e-06    2.60162e-06   0.000179102    2.254e-06    2.01813e-06     20000   
+apr_ue_highP:aprUeHighPTCFilter:TimeClusterFilter                                     6.311e-06    8.50767e-06   0.000277851    7.595e-06    3.67803e-06     20000   
+apr_ue_highP:aprUeHighPHSFilter:HelixFilter                                           4.629e-06    6.42055e-06   0.000117955    5.671e-06    2.49941e-06     16299   
+apr_highP:aprHighPPS:PrescaleEvent                                                    1.754e-06    2.60128e-06   0.000206705    2.265e-06    1.93413e-06     20000   
+apr_highP:aprHighPTCFilter:TimeClusterFilter                                          6.663e-06    8.75893e-06   0.000200343    7.885e-06    3.58937e-06     20000   
+apr_highP:aprHighPHSFilter:HelixFilter                                                4.689e-06    6.32781e-06   0.000210472    5.581e-06    2.8085e-06      16299   
+apr_highP_stopTarg:aprHighPStopTargPS:PrescaleEvent                                   1.704e-06    2.4132e-06    2.7081e-05     2.154e-06    1.09674e-06     20000   
+apr_highP_stopTarg:aprHighPStopTargTCFilter:TimeClusterFilter                         6.573e-06    8.62517e-06   7.8591e-05     7.805e-06    2.8974e-06      20000   
+apr_highP_stopTarg:aprHighPStopTargHSFilter:HelixFilter                               4.899e-06    6.5353e-06    0.000196165    5.801e-06    2.74991e-06     16299   
+cprHelixUe:cprHelixUePS:PrescaleEvent                                                 1.763e-06    2.48238e-06   4.0218e-05     2.185e-06    1.27325e-06     20000   
+cprHelixUe:TTCalTimePeakFinderUe:CalTimePeakFinder                                    8.686e-06    1.42903e-05   0.000339339   1.1031e-05    9.44959e-06     20000   
+cprHelixUe:cprHelixUeTCFilter:TimeClusterFilter                                       7.535e-06    9.66842e-06   0.000216694    8.757e-06    3.94424e-06     20000   
+cprHelixDe:cprHelixDePS:PrescaleEvent                                                 1.783e-06    2.53934e-06   2.4077e-05     2.264e-06    1.07775e-06     20000   
+cprHelixDe:TTCalTimePeakFinder:CalTimePeakFinder                                      6.943e-06    1.10816e-05   0.000450913    8.145e-06    9.04947e-06     20000   
+cprHelixDe:cprHelixDeTCFilter:TimeClusterFilter                                       7.043e-06    8.93663e-06   0.00104207     7.986e-06    8.01382e-06     20000   
+cprDe_lowP_stopTarg:cprDeLowPStopTargPS:PrescaleEvent                                 1.733e-06    2.58394e-06   0.000190604    2.255e-06    2.34166e-06     20000   
+cprDe_lowP_stopTarg:cprDeLowPStopTargTCFilter:TimeClusterFilter                       6.552e-06    8.62856e-06   0.000537628    7.594e-06    5.15012e-06     20000   
+cprDe_highP:cprDeHighPPS:PrescaleEvent                                                1.653e-06    2.26484e-06   3.4796e-05     2.034e-06    1.08193e-06     20000   
+cprDe_highP:cprDeHighPTCFilter:TimeClusterFilter                                      6.181e-06    8.0062e-06    0.000213599    7.123e-06    3.37624e-06     20000   
+cprDe_highP_stopTarg:cprDeHighPStopTargPS:PrescaleEvent                               1.653e-06    2.27991e-06   0.000236042    2.004e-06    2.01327e-06     20000   
+cprDe_highP_stopTarg:cprDeHighPStopTargTCFilter:TimeClusterFilter                     6.042e-06    7.8877e-06    0.000240009    7.073e-06    3.15225e-06     20000   
+tprHelixUe:tprHelixUePS:PrescaleEvent                                                 1.713e-06    2.45735e-06   0.000161038    2.144e-06    1.65322e-06     20000   
+tprHelixUe:TTtimeClusterFinderUe:TimeClusterFinder                                   2.9787e-05    0.00185366     0.030309     0.00110348    0.00231283      20000   
+tprHelixUe:tprHelixUeTCFilter:TimeClusterFilter                                       8.005e-06    1.45176e-05   0.000955127   1.3356e-05    8.90085e-06     20000   
+tprHelixUe:TThelixFinderUe:RobustHelixFinder                                         1.0289e-05    0.000617815    0.0215239    0.000336233   0.000910652     19881   
+tprHelixUe:TTHelixMergerUe:MergeHelices                                              1.0599e-05    1.78669e-05   0.000404643   1.5681e-05    8.8856e-06      19881   
+tprHelixUe:tprHelixUeHSFilter:HelixFilter                                             5.872e-06    9.7876e-06    0.000220421    8.386e-06    4.92167e-06     19881   
+tprHelixDe:tprHelixDePS:PrescaleEvent                                                 1.873e-06    3.68534e-06   0.000324691    3.397e-06    3.23801e-06     20000   
+tprHelixDe:TTtimeClusterFinder:TimeClusterFinder                                     2.6731e-05    0.00177433     0.0315573    0.00104139    0.00226952      20000   
+tprHelixDe:tprHelixDeTCFilter:TimeClusterFilter                                       7.505e-06    1.46821e-05   0.000991756   1.3446e-05    9.70422e-06     20000   
+tprHelixDe:TThelixFinder:RobustHelixFinder                                            8.135e-06    0.000669633    0.0184978    0.000347605   0.00103089      19889   
+tprHelixDe:TTHelixMergerDe:MergeHelices                                               9.528e-06    1.73901e-05   0.000379926   1.5429e-05    7.74449e-06     19889   
+tprHelixDe:tprHelixDeHSFilter:HelixFilter                                             5.37e-06     9.53394e-06   0.000341162    8.206e-06     5.261e-06      19889   
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledPS:PrescaleEvent                       1.924e-06    3.54564e-06   7.5525e-05     3.276e-06    1.51888e-06     20000   
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTCFilter:TimeClusterFilter             6.562e-06    1.20208e-05   0.000357453   1.1192e-05    5.44415e-06     20000   
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledHSFilter:HelixFilter                   4.839e-06    7.28855e-06   0.00405822     6.263e-06    2.88685e-05     19889   
+tprHelixDe_ipa:tprHelixDeIpaPS:PrescaleEvent                                          1.693e-06    2.60141e-06   2.4777e-05     2.385e-06    1.11193e-06     20000   
+tprHelixDe_ipa:tprHelixDeIpaTCFilter:TimeClusterFilter                                6.523e-06    9.74495e-06   0.00043954     8.877e-06    4.54519e-06     20000   
+tprHelixDe_ipa:tprHelixDeIpaHSFilter:HelixFilter                                      4.588e-06    6.53719e-06   0.000215222    5.791e-06    2.99746e-06     19889   
+tprDe_lowP_stopTarg:tprDeLowPStopTargPS:PrescaleEvent                                 1.753e-06    2.56659e-06   0.000181306    2.255e-06    1.72776e-06     20000   
+tprDe_lowP_stopTarg:tprDeLowPStopTargTCFilter:TimeClusterFilter                       6.523e-06    9.23421e-06   0.000390066    8.295e-06    5.8428e-06      20000   
+tprDe_lowP_stopTarg:tprDeLowPStopTargHSFilter:HelixFilter                             4.94e-06     7.25088e-06   0.000219891    6.432e-06    3.52824e-06     19935   
+tprDe_highP:tprDeHighPPS:PrescaleEvent                                                1.783e-06    2.65378e-06   0.000213096    2.254e-06    2.32244e-06     20000   
+tprDe_highP:tprDeHighPTCFilter:TimeClusterFilter                                      6.513e-06    9.28965e-06   0.000227595    8.165e-06    3.49499e-06     20000   
+tprDe_highP:tprDeHighPHSFilter:HelixFilter                                            4.639e-06    7.02659e-06   0.000201516    5.912e-06    3.95576e-06     19889   
+tprDe_highP_stopTarg:tprDeHighPStopTargPS:PrescaleEvent                               1.733e-06    2.46776e-06   0.000118537    2.175e-06    1.4633e-06      20000   
+tprDe_highP_stopTarg:tprDeHighPStopTargTCFilter:TimeClusterFilter                     6.312e-06    8.88617e-06   0.000265418    7.935e-06    3.74122e-06     20000   
+tprDe_highP_stopTarg:tprDeHighPStopTargHSFilter:HelixFilter                           4.779e-06    6.91762e-06   0.000195804    6.052e-06    3.09032e-06     19889   
+mprDe_highP_stopTarg:mprDeHighPStopTargPS:PrescaleEvent                               1.703e-06    2.45248e-06   0.000389234    2.144e-06    2.97587e-06     20000   
+mprDe_highP_stopTarg:mprDeHighPStopTargTCFilter:TimeClusterFilter                     6.594e-06    1.0904e-05    0.000529302    8.376e-06    1.99847e-05     20000   
+mprDe_highP_stopTarg:TTRobustMultiHelixFinder:RobustMultiHelixFinder                 1.7653e-05    0.00401922     0.185972     0.00145568    0.00854684      19889   
+mprDe_highP_stopTarg:TTMprHelixMergerDe:MergeHelices                                 1.3366e-05    0.000154684   0.00506703    4.6709e-05    0.000311564     19889   
+mprDe_highP_stopTarg:mprDeHighPStopTargHSFilter:HelixFilter                           5.59e-06     2.20633e-05   0.000361762   1.7794e-05    1.58466e-05     19889   
+mprDe_highP_stopTarg:TTMprKSFDe:LoopHelixFit                                         0.000149204    0.0123997     0.100165     0.00870155     0.0114958      12429   
+mprDe_highP_stopTarg:mprDeHighPStopTargKSFilter:KalSeedFilter                         8.166e-06    2.32729e-05   0.00258752    1.9577e-05    2.87266e-05     12429   
+lumiStream:lumiStreamPS:PrescaleEvent                                                 1.773e-06    4.10572e-06   0.000215372    3.706e-06    3.03401e-06     20000   
+lumiStream:lumiBuffer:LumiStreamFilter                                               2.2263e-05    3.03351e-05   0.000400936    2.635e-05    1.10894e-05     20000   
+[art]:TriggerResults:TriggerResultInserter                                            3.566e-06    5.31983e-06   0.000330652    4.47e-06     4.19098e-06     20000   
+cprHelixUe:TTCalHelixFinderUe:CalHelixFinder                                         2.9526e-05    0.000218399   0.00275202    0.000153382   0.00019706      1715    
+cprHelixUe:TTCalHelixMergerUe:MergeHelices                                           1.1281e-05    1.52824e-05   4.0357e-05    1.4298e-05    3.50888e-06     1715    
+cprHelixUe:cprHelixUeHSFilter:HelixFilter                                             5.871e-06    8.62997e-06   2.6941e-05     7.925e-06    2.33479e-06     1715    
+cprHelixDe:TTCalHelixFinderDe:CalHelixFinder                                          2.605e-05    0.000213421   0.00284669    0.000142402   0.000217078     1788    
+cprHelixDe:TTCalHelixMergerDe:MergeHelices                                            1.062e-05    1.52277e-05   0.000262521   1.4147e-05    6.76256e-06     1788    
+cprHelixDe:cprHelixDeHSFilter:HelixFilter                                             5.66e-06     9.07547e-06   0.000195814    8.185e-06    5.26831e-06     1788    
+cprDe_lowP_stopTarg:cprDeLowPStopTargHSFilter:HelixFilter                             5.651e-06    8.26886e-06   3.5497e-05     7.544e-06    2.6868e-06      1788    
+cprDe_highP:cprDeHighPHSFilter:HelixFilter                                            5.33e-06     7.79627e-06   3.7391e-05    7.1935e-06    2.37558e-06     1788    
+cprDe_highP_stopTarg:cprDeHighPStopTargHSFilter:HelixFilter                           5.39e-06     7.8132e-06     3.682e-05     7.239e-06    2.37299e-06     1788    
+tprHelixDe:tprHelixDeTriggerInfoMerger:MergeTriggerInfo                              1.4728e-05    2.49428e-05   0.000138204   2.1321e-05    1.04939e-05     1391    
+tprDe_lowP_stopTarg:TTKSFDe:LoopHelixFit                                             0.000166408   0.00202821     0.0126938     0.0017058    0.00142655      1698    
+tprDe_lowP_stopTarg:tprDeLowPStopTargKSFilter:KalSeedFilter                           8.446e-06    1.5831e-05    0.000237244   1.4863e-05    7.55557e-06     1698    
+apr_lowP_stopTarg:TTAprKSF:LoopHelixFit                                              0.000174894   0.00123597    0.00868614    0.00113339    0.00101972       564    
+apr_lowP_stopTarg:aprLowPStopTargKSFilter:KalSeedFilter                               5.531e-06    1.43693e-05   5.6999e-05    1.3195e-05    5.24136e-06      592    
+apr_lowP_stopTarg:aprLowPStopTargTriggerInfoMerger:MergeTriggerInfo                  1.5129e-05    2.43592e-05   6.5024e-05    2.06395e-05   8.92765e-06      124    
+mprDe_highP_stopTarg:mprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo            1.8686e-05    3.86898e-05   0.000246762   3.28735e-05   2.10603e-05      324    
+tprHelixUe:tprHelixUeTriggerInfoMerger:MergeTriggerInfo                              1.4958e-05    2.73834e-05   0.000385648    2.591e-05    1.3021e-05      1831    
+tprDe_lowP_stopTarg:tprDeLowPStopTargTriggerInfoMerger:MergeTriggerInfo              1.7993e-05    2.14561e-05   4.8112e-05    2.0119e-05    4.35175e-06      146    
+apr_ue_highP:TTAprUeKSF:LoopHelixFit                                                 0.000163452   0.00093188    0.00855083    0.000615492   0.000926447      314    
+apr_ue_highP:aprUeHighPKSFilter:KalSeedFilter                                         7.834e-06    1.19797e-05   3.3605e-05    1.0996e-05    3.63119e-06      314    
+apr_highP:TTAprKSF:LoopHelixFit                                                      0.000147933   0.000973711   0.00630389    0.000668297   0.000889277      133    
+apr_highP:aprHighPKSFilter:KalSeedFilter                                              5.36e-06     9.14484e-06   6.0596e-05     8.501e-06    3.89967e-06      314    
+aprHelix:aprHelixTriggerInfoMerger:MergeTriggerInfo                                  1.6432e-05    2.94546e-05   0.00012045    2.8645e-05    9.2496e-06      1259    
+tprDe_highP:tprDeHighPKSFilter:KalSeedFilter                                          5.18e-06     9.45893e-06   3.5828e-05     8.626e-06    3.96554e-06     1096    
+tprDe_highP_stopTarg:tprDeHighPStopTargKSFilter:KalSeedFilter                         4.719e-06    8.33624e-06   3.2472e-05     7.77e-06     3.12795e-06      684    
+tprDe_lowP_stopTarg:TThelixFinder:RobustHelixFinder                                   9.528e-06    3.82723e-05   0.000293421   1.74635e-05   5.33401e-05      46     
+tprDe_lowP_stopTarg:TTHelixMergerDe:MergeHelices                                     1.0991e-05    1.41263e-05   2.5108e-05    1.35415e-05   2.66632e-06      46     
+tprHelixDe_ipa:tprHelixDeIpaTriggerInfoMerger:MergeTriggerInfo                       1.0912e-05    1.72548e-05   8.8961e-05    1.52145e-05   7.77876e-06      536    
+tprHelixDe_ipa_phiScaled:tprHelixDeIpaPhiScaledTriggerInfoMerger:MergeTriggerInfo    1.2764e-05    1.89702e-05    4.728e-05    1.6732e-05    6.58842e-06      131    
+cprHelixDe:cprHelixDeTriggerInfoMerger:MergeTriggerInfo                              1.5199e-05    2.62239e-05    5.19e-05     2.2854e-05    8.72294e-06      81     
+cprDe_highP:TTCalSeedFitDe:LoopHelixFit                                              0.000341994   0.000977419   0.00183703    0.00100198    0.000549748       5     
+cprDe_highP:cprDeHighPKSFilter:KalSeedFilter                                          5.811e-06    8.9978e-06    1.9216e-05     7.325e-06    3.51549e-06      45     
+tprDe_highP:TTKSFDe:LoopHelixFit                                                     0.000197879   0.00158681     0.0068175    0.00122187    0.00122813       121    
+cprDe_lowP_stopTarg:TTCalSeedFitDe:LoopHelixFit                                      0.000182218   0.00101871    0.00373096    0.000957702   0.000715412      77     
+cprDe_lowP_stopTarg:cprDeLowPStopTargKSFilter:KalSeedFilter                           8.937e-06    1.40892e-05   2.9987e-05    1.2906e-05    4.40359e-06      77     
+apr_highP_stopTarg:aprHighPStopTargKSFilter:KalSeedFilter                             5.34e-06     7.37371e-06   1.7344e-05     6.943e-06    1.7672e-06       73     
+apr_lowP_multiHelix:TTAprKSF:LoopHelixFit                                            0.000409093   0.00222315    0.00686161    0.00190698    0.00148005       29     
+apr_lowP_multiHelix:aprLowPMultiHelixKSFilter:KalSeedFilter                           9.309e-06    1.60003e-05   4.2212e-05    1.2703e-05    6.97288e-06      29     
+apr_highP_stopTarg_multiTrk:aprHighPStopTargMultiTrkKSFilter:KalSeedFilter            6.793e-06    8.23414e-06    9.348e-06     8.046e-06    9.55675e-07       7     
+cprDe_highP_stopTarg:cprDeHighPStopTargKSFilter:KalSeedFilter                         5.532e-06    7.94411e-06   1.9918e-05     6.562e-06    3.17476e-06      19     
+cprDe_lowP_stopTarg:cprDeLowPStopTargTriggerInfoMerger:MergeTriggerInfo              1.8045e-05    2.17837e-05    3.152e-05    2.0309e-05    3.93225e-06      19     
+tprDe_highP:tprDeHighPTriggerInfoMerger:MergeTriggerInfo                              1.506e-05    1.77993e-05   2.0318e-05    1.79095e-05   1.96046e-06       4     
+apr_highP:aprHighPTriggerInfoMerger:MergeTriggerInfo                                 1.7073e-05    1.78345e-05   1.8596e-05    1.78345e-05    7.615e-07        2     
+apr_lowP_multiHelix:aprLowPMultiHelixTriggerInfoMerger:MergeTriggerInfo              2.0689e-05    2.4767e-05    2.8845e-05    2.4767e-05     4.078e-06        2     
+cprDe_highP:cprDeHighPTriggerInfoMerger:MergeTriggerInfo                             1.8265e-05    1.8265e-05    1.8265e-05    1.8265e-05         0            1     
+cprDe_highP_stopTarg:cprDeHighPStopTargTriggerInfoMerger:MergeTriggerInfo             1.553e-05     1.553e-05     1.553e-05     1.553e-05         0            1     
+apr_highP_stopTarg:aprHighPStopTargTriggerInfoMerger:MergeTriggerInfo                1.6532e-05    1.6532e-05    1.6532e-05    1.6532e-05         0            1     
 =======================================================================================================================================================================
 DbEngine::endJob
-    Total time in reading DB: 0.715166 s
+    Total time in reading DB: 0.854755 s
     Total time waiting for locks: 1e-06 s
-    Total time in locks: 0.536248 s
+    Total time in locks: 0.612567 s
     valcache memory: 78885 b
   Database cache stats:
     cache nTable : 11
@@ -231,39 +232,40 @@ DbEngine::endJob
     cache nPurged : 0
 
 TrigReport ---------- Event summary -------------
-TrigReport Events total = 20000 passed = 4885 failed = 15115
+TrigReport Events total = 20000 passed = 4800 failed = 15200
 
 TrigReport ---------- Trigger-path summary ------------
 TrigReport    Path ID        Run     Passed     Failed      Error Name
-TrigReport        100      20000          1      19999          0 tprDe_highP_stopTarg
-TrigReport        101      20000          5      19995          0 tprDe_highP
-TrigReport        110      20000        141      19859          0 tprDe_lowP_stopTarg
-TrigReport        120      20000        552      19448          0 tprHelixDe_ipa
-TrigReport        121      20000        147      19853          0 tprHelixDe_ipa_phiScaled
-TrigReport        130      20000       1446      18554          0 tprHelixDe
-TrigReport        131      20000       1940      18060          0 tprHelixUe
+TrigReport        100      20000          0      20000          0 tprDe_highP_stopTarg
+TrigReport        101      20000          4      19996          0 tprDe_highP
+TrigReport        110      20000        146      19854          0 tprDe_lowP_stopTarg
+TrigReport        120      20000        536      19464          0 tprHelixDe_ipa
+TrigReport        121      20000        131      19869          0 tprHelixDe_ipa_phiScaled
+TrigReport        130      20000       1391      18609          0 tprHelixDe
+TrigReport        131      20000       1831      18169          0 tprHelixUe
 TrigReport        150      20000          1      19999          0 cprDe_highP_stopTarg
 TrigReport        151      20000          1      19999          0 cprDe_highP
-TrigReport        160      20000         20      19980          0 cprDe_lowP_stopTarg
-TrigReport        170      20000         82      19918          0 cprHelixDe
-TrigReport        171      20000         34      19966          0 cprHelixUe
+TrigReport        160      20000         19      19981          0 cprDe_lowP_stopTarg
+TrigReport        170      20000         81      19919          0 cprHelixDe
+TrigReport        171      20000         35      19965          0 cprHelixUe
 TrigReport        180      20000          1      19999          0 apr_highP_stopTarg
 TrigReport        181      20000          2      19998          0 apr_highP
 TrigReport        185      20000          0      20000          0 apr_ue_highP
-TrigReport        190      20000        133      19867          0 apr_lowP_stopTarg
+TrigReport        190      20000        124      19876          0 apr_lowP_stopTarg
 TrigReport        191      20000          0      20000          0 apr_highP_stopTarg_multiTrk
-TrigReport        192      20000          3      19997          0 apr_lowP_multiHelix
-TrigReport        195      20000       1305      18695          0 aprHelix
+TrigReport        192      20000          2      19998          0 apr_lowP_multiHelix
+TrigReport        195      20000       1259      18741          0 aprHelix
 TrigReport        200      20000        471      19529          0 caloFast_photon
-TrigReport        201      20000       1844      18156          0 caloFast_MVANNCE
+TrigReport        201      20000       1858      18142          0 caloFast_MVANNCE
 TrigReport        202      20000          0      20000          0 caloFast_cosmic
-TrigReport        210      20000        318      19682          0 mprDe_highP_stopTarg
+TrigReport        210      20000        324      19676          0 mprDe_highP_stopTarg
 TrigReport        220      20000          0      20000          0 caloFast_RMC
 TrigReport        310      20000          0      20000          0 cstTimeCluster
 TrigReport        320      20000          0      20000          0 cstCosmicTrackSeed
 TrigReport        400      20000          0      20000          0 minBias_SDCount
 TrigReport        410      20000          0      20000          0 minBias_CDCount
 TrigReport        500      20000          0      20000          0 caloHitRec_N0Source
+TrigReport        800      20000          6      19994          0 lumiStream
 
 TrigReport ---------- End-path summary ---------
 TrigReport        Run    Success      Error
@@ -279,11 +281,11 @@ TrigReport        195      20000      20000          0          0 TTmakeSH
 TrigReport        195      20000      20000          0          0 TTmakePH
 TrigReport        195      20000      20000          0          0 TTflagPH
 TrigReport        195      20000      20000          0          0 TTTZClusterFinder
-TrigReport        195      20000      16392       3608          0 aprHelixTCFilter
-TrigReport        195      16392      16392          0          0 TTAprHelixFinder
-TrigReport        195      16392      16392          0          0 TTAprHelixMerger
-TrigReport        195      16392       1305      15087          0 aprHelixHSFilter
-TrigReport        195       1305       1305          0          0 aprHelixTriggerInfoMerger
+TrigReport        195      20000      16299       3701          0 aprHelixTCFilter
+TrigReport        195      16299      16299          0          0 TTAprHelixFinder
+TrigReport        195      16299      16299          0          0 TTAprHelixMerger
+TrigReport        195      16299       1259      15040          0 aprHelixHSFilter
+TrigReport        195       1259       1259          0          0 aprHelixTriggerInfoMerger
 
 TrigReport ---------- Modules in path: apr_highP ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -296,12 +298,12 @@ TrigReport        181      20000      20000          0          0 TTmakeSH
 TrigReport        181      20000      20000          0          0 TTmakePH
 TrigReport        181      20000      20000          0          0 TTflagPH
 TrigReport        181      20000      20000          0          0 TTTZClusterFinder
-TrigReport        181      20000      16392       3608          0 aprHighPTCFilter
-TrigReport        181      16392      16392          0          0 TTAprHelixFinder
-TrigReport        181      16392      16392          0          0 TTAprHelixMerger
-TrigReport        181      16392        321      16071          0 aprHighPHSFilter
-TrigReport        181        321        321          0          0 TTAprKSF
-TrigReport        181        321          2        319          0 aprHighPKSFilter
+TrigReport        181      20000      16299       3701          0 aprHighPTCFilter
+TrigReport        181      16299      16299          0          0 TTAprHelixFinder
+TrigReport        181      16299      16299          0          0 TTAprHelixMerger
+TrigReport        181      16299        314      15985          0 aprHighPHSFilter
+TrigReport        181        314        314          0          0 TTAprKSF
+TrigReport        181        314          2        312          0 aprHighPKSFilter
 TrigReport        181          2          2          0          0 aprHighPTriggerInfoMerger
 
 TrigReport ---------- Modules in path: apr_highP_stopTarg ------------
@@ -315,12 +317,12 @@ TrigReport        180      20000      20000          0          0 TTmakeSH
 TrigReport        180      20000      20000          0          0 TTmakePH
 TrigReport        180      20000      20000          0          0 TTflagPH
 TrigReport        180      20000      20000          0          0 TTTZClusterFinder
-TrigReport        180      20000      16392       3608          0 aprHighPStopTargTCFilter
-TrigReport        180      16392      16392          0          0 TTAprHelixFinder
-TrigReport        180      16392      16392          0          0 TTAprHelixMerger
-TrigReport        180      16392         79      16313          0 aprHighPStopTargHSFilter
-TrigReport        180         79         79          0          0 TTAprKSF
-TrigReport        180         79          1         78          0 aprHighPStopTargKSFilter
+TrigReport        180      20000      16299       3701          0 aprHighPStopTargTCFilter
+TrigReport        180      16299      16299          0          0 TTAprHelixFinder
+TrigReport        180      16299      16299          0          0 TTAprHelixMerger
+TrigReport        180      16299         73      16226          0 aprHighPStopTargHSFilter
+TrigReport        180         73         73          0          0 TTAprKSF
+TrigReport        180         73          1         72          0 aprHighPStopTargKSFilter
 TrigReport        180          1          1          0          0 aprHighPStopTargTriggerInfoMerger
 
 TrigReport ---------- Modules in path: apr_highP_stopTarg_multiTrk ------------
@@ -334,12 +336,12 @@ TrigReport        191      20000      20000          0          0 TTmakeSH
 TrigReport        191      20000      20000          0          0 TTmakePH
 TrigReport        191      20000      20000          0          0 TTflagPH
 TrigReport        191      20000      20000          0          0 TTTZClusterFinder
-TrigReport        191      20000      16392       3608          0 aprHighPStopTargMultiTrkTCFilter
-TrigReport        191      16392      16392          0          0 TTAprHelixFinder
-TrigReport        191      16392      16392          0          0 TTAprHelixMerger
-TrigReport        191      16392          6      16386          0 aprHighPStopTargMultiTrkHSFilter
-TrigReport        191          6          6          0          0 TTAprKSF
-TrigReport        191          6          0          6          0 aprHighPStopTargMultiTrkKSFilter
+TrigReport        191      20000      16299       3701          0 aprHighPStopTargMultiTrkTCFilter
+TrigReport        191      16299      16299          0          0 TTAprHelixFinder
+TrigReport        191      16299      16299          0          0 TTAprHelixMerger
+TrigReport        191      16299          7      16292          0 aprHighPStopTargMultiTrkHSFilter
+TrigReport        191          7          7          0          0 TTAprKSF
+TrigReport        191          7          0          7          0 aprHighPStopTargMultiTrkKSFilter
 TrigReport        191          0          0          0          0 aprHighPStopTargMultiTrkTriggerInfoMerger
 
 TrigReport ---------- Modules in path: apr_lowP_multiHelix ------------
@@ -353,13 +355,13 @@ TrigReport        192      20000      20000          0          0 TTmakeSH
 TrigReport        192      20000      20000          0          0 TTmakePH
 TrigReport        192      20000      20000          0          0 TTflagPH
 TrigReport        192      20000      20000          0          0 TTTZClusterFinder
-TrigReport        192      20000      16392       3608          0 aprLowPMultiHelixTCFilter
-TrigReport        192      16392      16392          0          0 TTAprHelixFinder
-TrigReport        192      16392      16392          0          0 TTAprHelixMerger
-TrigReport        192      16392         29      16363          0 aprLowPMultiHelixHSFilter
+TrigReport        192      20000      16299       3701          0 aprLowPMultiHelixTCFilter
+TrigReport        192      16299      16299          0          0 TTAprHelixFinder
+TrigReport        192      16299      16299          0          0 TTAprHelixMerger
+TrigReport        192      16299         29      16270          0 aprLowPMultiHelixHSFilter
 TrigReport        192         29         29          0          0 TTAprKSF
-TrigReport        192         29          3         26          0 aprLowPMultiHelixKSFilter
-TrigReport        192          3          3          0          0 aprLowPMultiHelixTriggerInfoMerger
+TrigReport        192         29          2         27          0 aprLowPMultiHelixKSFilter
+TrigReport        192          2          2          0          0 aprLowPMultiHelixTriggerInfoMerger
 
 TrigReport ---------- Modules in path: apr_lowP_stopTarg ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -372,13 +374,13 @@ TrigReport        190      20000      20000          0          0 TTmakeSH
 TrigReport        190      20000      20000          0          0 TTmakePH
 TrigReport        190      20000      20000          0          0 TTflagPH
 TrigReport        190      20000      20000          0          0 TTTZClusterFinder
-TrigReport        190      20000      16392       3608          0 aprLowPStopTargTCFilter
-TrigReport        190      16392      16392          0          0 TTAprHelixFinder
-TrigReport        190      16392      16392          0          0 TTAprHelixMerger
-TrigReport        190      16392        593      15799          0 aprLowPStopTargHSFilter
-TrigReport        190        593        593          0          0 TTAprKSF
-TrigReport        190        593        133        460          0 aprLowPStopTargKSFilter
-TrigReport        190        133        133          0          0 aprLowPStopTargTriggerInfoMerger
+TrigReport        190      20000      16299       3701          0 aprLowPStopTargTCFilter
+TrigReport        190      16299      16299          0          0 TTAprHelixFinder
+TrigReport        190      16299      16299          0          0 TTAprHelixMerger
+TrigReport        190      16299        592      15707          0 aprLowPStopTargHSFilter
+TrigReport        190        592        592          0          0 TTAprKSF
+TrigReport        190        592        124        468          0 aprLowPStopTargKSFilter
+TrigReport        190        124        124          0          0 aprLowPStopTargTriggerInfoMerger
 
 TrigReport ---------- Modules in path: apr_ue_highP ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -391,12 +393,12 @@ TrigReport        185      20000      20000          0          0 TTmakeSH
 TrigReport        185      20000      20000          0          0 TTmakePH
 TrigReport        185      20000      20000          0          0 TTflagPH
 TrigReport        185      20000      20000          0          0 TTTZClusterFinder
-TrigReport        185      20000      16392       3608          0 aprUeHighPTCFilter
-TrigReport        185      16392      16392          0          0 TTAprHelixFinder
-TrigReport        185      16392      16392          0          0 TTAprHelixMerger
-TrigReport        185      16392        321      16071          0 aprUeHighPHSFilter
-TrigReport        185        321        321          0          0 TTAprUeKSF
-TrigReport        185        321          0        321          0 aprUeHighPKSFilter
+TrigReport        185      20000      16299       3701          0 aprUeHighPTCFilter
+TrigReport        185      16299      16299          0          0 TTAprHelixFinder
+TrigReport        185      16299      16299          0          0 TTAprHelixMerger
+TrigReport        185      16299        314      15985          0 aprUeHighPHSFilter
+TrigReport        185        314        314          0          0 TTAprUeKSF
+TrigReport        185        314          0        314          0 aprUeHighPKSFilter
 TrigReport        185          0          0          0          0 aprUeHighPTriggerInfoMerger
 
 TrigReport ---------- Modules in path: caloFast_MVANNCE ------------
@@ -405,7 +407,7 @@ TrigReport        201      20000      20000          0          0 processCFOData
 TrigReport        201      20000      20000          0          0 caloFastMVANNCEPS
 TrigReport        201      20000      20000          0          0 CaloHitMakerFast
 TrigReport        201      20000      20000          0          0 CaloClusterFast
-TrigReport        201      20000       1844      18156          0 caloFastMVANNCEFilter
+TrigReport        201      20000       1858      18142          0 caloFastMVANNCEFilter
 
 TrigReport ---------- Modules in path: caloFast_RMC ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -449,12 +451,12 @@ TrigReport        151      20000      20000          0          0 TTmakeSH
 TrigReport        151      20000      20000          0          0 TTmakePH
 TrigReport        151      20000      20000          0          0 TTflagPH
 TrigReport        151      20000      20000          0          0 TTCalTimePeakFinder
-TrigReport        151      20000       1794      18206          0 cprDeHighPTCFilter
-TrigReport        151       1794       1794          0          0 TTCalHelixFinderDe
-TrigReport        151       1794       1794          0          0 TTCalHelixMergerDe
-TrigReport        151       1794         46       1748          0 cprDeHighPHSFilter
-TrigReport        151         46         46          0          0 TTCalSeedFitDe
-TrigReport        151         46          1         45          0 cprDeHighPKSFilter
+TrigReport        151      20000       1788      18212          0 cprDeHighPTCFilter
+TrigReport        151       1788       1788          0          0 TTCalHelixFinderDe
+TrigReport        151       1788       1788          0          0 TTCalHelixMergerDe
+TrigReport        151       1788         45       1743          0 cprDeHighPHSFilter
+TrigReport        151         45         45          0          0 TTCalSeedFitDe
+TrigReport        151         45          1         44          0 cprDeHighPKSFilter
 TrigReport        151          1          1          0          0 cprDeHighPTriggerInfoMerger
 
 TrigReport ---------- Modules in path: cprDe_highP_stopTarg ------------
@@ -468,12 +470,12 @@ TrigReport        150      20000      20000          0          0 TTmakeSH
 TrigReport        150      20000      20000          0          0 TTmakePH
 TrigReport        150      20000      20000          0          0 TTflagPH
 TrigReport        150      20000      20000          0          0 TTCalTimePeakFinder
-TrigReport        150      20000       1794      18206          0 cprDeHighPStopTargTCFilter
-TrigReport        150       1794       1794          0          0 TTCalHelixFinderDe
-TrigReport        150       1794       1794          0          0 TTCalHelixMergerDe
-TrigReport        150       1794         20       1774          0 cprDeHighPStopTargHSFilter
-TrigReport        150         20         20          0          0 TTCalSeedFitDe
-TrigReport        150         20          1         19          0 cprDeHighPStopTargKSFilter
+TrigReport        150      20000       1788      18212          0 cprDeHighPStopTargTCFilter
+TrigReport        150       1788       1788          0          0 TTCalHelixFinderDe
+TrigReport        150       1788       1788          0          0 TTCalHelixMergerDe
+TrigReport        150       1788         19       1769          0 cprDeHighPStopTargHSFilter
+TrigReport        150         19         19          0          0 TTCalSeedFitDe
+TrigReport        150         19          1         18          0 cprDeHighPStopTargKSFilter
 TrigReport        150          1          1          0          0 cprDeHighPStopTargTriggerInfoMerger
 
 TrigReport ---------- Modules in path: cprDe_lowP_stopTarg ------------
@@ -487,13 +489,13 @@ TrigReport        160      20000      20000          0          0 TTmakeSH
 TrigReport        160      20000      20000          0          0 TTmakePH
 TrigReport        160      20000      20000          0          0 TTflagPH
 TrigReport        160      20000      20000          0          0 TTCalTimePeakFinder
-TrigReport        160      20000       1794      18206          0 cprDeLowPStopTargTCFilter
-TrigReport        160       1794       1794          0          0 TTCalHelixFinderDe
-TrigReport        160       1794       1794          0          0 TTCalHelixMergerDe
-TrigReport        160       1794         78       1716          0 cprDeLowPStopTargHSFilter
-TrigReport        160         78         78          0          0 TTCalSeedFitDe
-TrigReport        160         78         20         58          0 cprDeLowPStopTargKSFilter
-TrigReport        160         20         20          0          0 cprDeLowPStopTargTriggerInfoMerger
+TrigReport        160      20000       1788      18212          0 cprDeLowPStopTargTCFilter
+TrigReport        160       1788       1788          0          0 TTCalHelixFinderDe
+TrigReport        160       1788       1788          0          0 TTCalHelixMergerDe
+TrigReport        160       1788         77       1711          0 cprDeLowPStopTargHSFilter
+TrigReport        160         77         77          0          0 TTCalSeedFitDe
+TrigReport        160         77         19         58          0 cprDeLowPStopTargKSFilter
+TrigReport        160         19         19          0          0 cprDeLowPStopTargTriggerInfoMerger
 
 TrigReport ---------- Modules in path: cprHelixDe ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -506,11 +508,11 @@ TrigReport        170      20000      20000          0          0 TTmakeSH
 TrigReport        170      20000      20000          0          0 TTmakePH
 TrigReport        170      20000      20000          0          0 TTflagPH
 TrigReport        170      20000      20000          0          0 TTCalTimePeakFinder
-TrigReport        170      20000       1794      18206          0 cprHelixDeTCFilter
-TrigReport        170       1794       1794          0          0 TTCalHelixFinderDe
-TrigReport        170       1794       1794          0          0 TTCalHelixMergerDe
-TrigReport        170       1794         82       1712          0 cprHelixDeHSFilter
-TrigReport        170         82         82          0          0 cprHelixDeTriggerInfoMerger
+TrigReport        170      20000       1788      18212          0 cprHelixDeTCFilter
+TrigReport        170       1788       1788          0          0 TTCalHelixFinderDe
+TrigReport        170       1788       1788          0          0 TTCalHelixMergerDe
+TrigReport        170       1788         81       1707          0 cprHelixDeHSFilter
+TrigReport        170         81         81          0          0 cprHelixDeTriggerInfoMerger
 
 TrigReport ---------- Modules in path: cprHelixUe ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -523,10 +525,10 @@ TrigReport        171      20000      20000          0          0 TTmakeSH
 TrigReport        171      20000      20000          0          0 TTmakePH
 TrigReport        171      20000      20000          0          0 TTflagPH
 TrigReport        171      20000      20000          0          0 TTCalTimePeakFinderUe
-TrigReport        171      20000       1738      18262          0 cprHelixUeTCFilter
-TrigReport        171       1738       1738          0          0 TTCalHelixFinderUe
-TrigReport        171       1738       1738          0          0 TTCalHelixMergerUe
-TrigReport        171       1738         34       1704          0 cprHelixUeHSFilter
+TrigReport        171      20000       1715      18285          0 cprHelixUeTCFilter
+TrigReport        171       1715       1715          0          0 TTCalHelixFinderUe
+TrigReport        171       1715       1715          0          0 TTCalHelixMergerUe
+TrigReport        171       1715         35       1680          0 cprHelixUeHSFilter
 
 TrigReport ---------- Modules in path: cstCosmicTrackSeed ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -554,6 +556,19 @@ TrigReport        310          0          0          0          0 CstSimpleTimeC
 TrigReport        310          0          0          0          0 cstTimeClusterTCFilter
 TrigReport        310          0          0          0          0 cstTimeClusterTriggerInfoMerger
 
+TrigReport ---------- Modules in path: lumiStream ------------
+TrigReport    Path ID    Visited     Passed     Failed      Error Name
+TrigReport        800      20000      20000          0          0 processCFOData
+TrigReport        800      20000      20000          0          0 lumiStreamPS
+TrigReport        800      20000      20000          0          0 CaloHitMakerFast
+TrigReport        800      20000      20000          0          0 CaloClusterFast
+TrigReport        800      20000      20000          0          0 TTmakeSD
+TrigReport        800      20000      20000          0          0 TTmakeSH
+TrigReport        800      20000      20000          0          0 TTmakePH
+TrigReport        800      20000      20000          0          0 TTflagPH
+TrigReport        800      20000      20000          0          0 TTTZClusterFinder
+TrigReport        800      20000          6      19994          0 lumiBuffer
+
 TrigReport ---------- Modules in path: minBias_CDCount ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
 TrigReport        410      20000      20000          0          0 processCFOData
@@ -577,13 +592,13 @@ TrigReport        210      20000      20000          0          0 TTmakeSH
 TrigReport        210      20000      20000          0          0 TTmakePH
 TrigReport        210      20000      20000          0          0 TTflagPH
 TrigReport        210      20000      20000          0          0 TTtimeClusterFinder
-TrigReport        210      20000      19893        107          0 mprDeHighPStopTargTCFilter
-TrigReport        210      19893      19893          0          0 TTRobustMultiHelixFinder
-TrigReport        210      19893      19893          0          0 TTMprHelixMergerDe
-TrigReport        210      19893      12558       7335          0 mprDeHighPStopTargHSFilter
-TrigReport        210      12558      12558          0          0 TTMprKSFDe
-TrigReport        210      12558        318      12240          0 mprDeHighPStopTargKSFilter
-TrigReport        210        318        318          0          0 mprDeHighPStopTargTriggerInfoMerger
+TrigReport        210      20000      19889        111          0 mprDeHighPStopTargTCFilter
+TrigReport        210      19889      19889          0          0 TTRobustMultiHelixFinder
+TrigReport        210      19889      19889          0          0 TTMprHelixMergerDe
+TrigReport        210      19889      12429       7460          0 mprDeHighPStopTargHSFilter
+TrigReport        210      12429      12429          0          0 TTMprKSFDe
+TrigReport        210      12429        324      12105          0 mprDeHighPStopTargKSFilter
+TrigReport        210        324        324          0          0 mprDeHighPStopTargTriggerInfoMerger
 
 TrigReport ---------- Modules in path: tprDe_highP ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -596,13 +611,13 @@ TrigReport        101      20000      20000          0          0 TTmakeSH
 TrigReport        101      20000      20000          0          0 TTmakePH
 TrigReport        101      20000      20000          0          0 TTflagPH
 TrigReport        101      20000      20000          0          0 TTtimeClusterFinder
-TrigReport        101      20000      19893        107          0 tprDeHighPTCFilter
-TrigReport        101      19893      19893          0          0 TThelixFinder
-TrigReport        101      19893      19893          0          0 TTHelixMergerDe
-TrigReport        101      19893       1125      18768          0 tprDeHighPHSFilter
-TrigReport        101       1125       1125          0          0 TTKSFDe
-TrigReport        101       1125          5       1120          0 tprDeHighPKSFilter
-TrigReport        101          5          5          0          0 tprDeHighPTriggerInfoMerger
+TrigReport        101      20000      19889        111          0 tprDeHighPTCFilter
+TrigReport        101      19889      19889          0          0 TThelixFinder
+TrigReport        101      19889      19889          0          0 TTHelixMergerDe
+TrigReport        101      19889       1096      18793          0 tprDeHighPHSFilter
+TrigReport        101       1096       1096          0          0 TTKSFDe
+TrigReport        101       1096          4       1092          0 tprDeHighPKSFilter
+TrigReport        101          4          4          0          0 tprDeHighPTriggerInfoMerger
 
 TrigReport ---------- Modules in path: tprDe_highP_stopTarg ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -615,13 +630,13 @@ TrigReport        100      20000      20000          0          0 TTmakeSH
 TrigReport        100      20000      20000          0          0 TTmakePH
 TrigReport        100      20000      20000          0          0 TTflagPH
 TrigReport        100      20000      20000          0          0 TTtimeClusterFinder
-TrigReport        100      20000      19893        107          0 tprDeHighPStopTargTCFilter
-TrigReport        100      19893      19893          0          0 TThelixFinder
-TrigReport        100      19893      19893          0          0 TTHelixMergerDe
-TrigReport        100      19893        712      19181          0 tprDeHighPStopTargHSFilter
-TrigReport        100        712        712          0          0 TTKSFDe
-TrigReport        100        712          1        711          0 tprDeHighPStopTargKSFilter
-TrigReport        100          1          1          0          0 tprDeHighPStopTargTriggerInfoMerger
+TrigReport        100      20000      19889        111          0 tprDeHighPStopTargTCFilter
+TrigReport        100      19889      19889          0          0 TThelixFinder
+TrigReport        100      19889      19889          0          0 TTHelixMergerDe
+TrigReport        100      19889        684      19205          0 tprDeHighPStopTargHSFilter
+TrigReport        100        684        684          0          0 TTKSFDe
+TrigReport        100        684          0        684          0 tprDeHighPStopTargKSFilter
+TrigReport        100          0          0          0          0 tprDeHighPStopTargTriggerInfoMerger
 
 TrigReport ---------- Modules in path: tprDe_lowP_stopTarg ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -634,13 +649,13 @@ TrigReport        110      20000      20000          0          0 TTmakeSH
 TrigReport        110      20000      20000          0          0 TTmakePH
 TrigReport        110      20000      20000          0          0 TTflagPH
 TrigReport        110      20000      20000          0          0 TTtimeClusterFinder
-TrigReport        110      20000      19937         63          0 tprDeLowPStopTargTCFilter
-TrigReport        110      19937      19937          0          0 TThelixFinder
-TrigReport        110      19937      19937          0          0 TTHelixMergerDe
-TrigReport        110      19937       1774      18163          0 tprDeLowPStopTargHSFilter
-TrigReport        110       1774       1774          0          0 TTKSFDe
-TrigReport        110       1774        141       1633          0 tprDeLowPStopTargKSFilter
-TrigReport        110        141        141          0          0 tprDeLowPStopTargTriggerInfoMerger
+TrigReport        110      20000      19935         65          0 tprDeLowPStopTargTCFilter
+TrigReport        110      19935      19935          0          0 TThelixFinder
+TrigReport        110      19935      19935          0          0 TTHelixMergerDe
+TrigReport        110      19935       1698      18237          0 tprDeLowPStopTargHSFilter
+TrigReport        110       1698       1698          0          0 TTKSFDe
+TrigReport        110       1698        146       1552          0 tprDeLowPStopTargKSFilter
+TrigReport        110        146        146          0          0 tprDeLowPStopTargTriggerInfoMerger
 
 TrigReport ---------- Modules in path: tprHelixDe ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -653,11 +668,11 @@ TrigReport        130      20000      20000          0          0 TTmakeSH
 TrigReport        130      20000      20000          0          0 TTmakePH
 TrigReport        130      20000      20000          0          0 TTflagPH
 TrigReport        130      20000      20000          0          0 TTtimeClusterFinder
-TrigReport        130      20000      19893        107          0 tprHelixDeTCFilter
-TrigReport        130      19893      19893          0          0 TThelixFinder
-TrigReport        130      19893      19893          0          0 TTHelixMergerDe
-TrigReport        130      19893       1446      18447          0 tprHelixDeHSFilter
-TrigReport        130       1446       1446          0          0 tprHelixDeTriggerInfoMerger
+TrigReport        130      20000      19889        111          0 tprHelixDeTCFilter
+TrigReport        130      19889      19889          0          0 TThelixFinder
+TrigReport        130      19889      19889          0          0 TTHelixMergerDe
+TrigReport        130      19889       1391      18498          0 tprHelixDeHSFilter
+TrigReport        130       1391       1391          0          0 tprHelixDeTriggerInfoMerger
 
 TrigReport ---------- Modules in path: tprHelixDe_ipa ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -670,11 +685,11 @@ TrigReport        120      20000      20000          0          0 TTmakeSH
 TrigReport        120      20000      20000          0          0 TTmakePH
 TrigReport        120      20000      20000          0          0 TTflagPH
 TrigReport        120      20000      20000          0          0 TTtimeClusterFinder
-TrigReport        120      20000      19893        107          0 tprHelixDeIpaTCFilter
-TrigReport        120      19893      19893          0          0 TThelixFinder
-TrigReport        120      19893      19893          0          0 TTHelixMergerDe
-TrigReport        120      19893        552      19341          0 tprHelixDeIpaHSFilter
-TrigReport        120        552        552          0          0 tprHelixDeIpaTriggerInfoMerger
+TrigReport        120      20000      19889        111          0 tprHelixDeIpaTCFilter
+TrigReport        120      19889      19889          0          0 TThelixFinder
+TrigReport        120      19889      19889          0          0 TTHelixMergerDe
+TrigReport        120      19889        536      19353          0 tprHelixDeIpaHSFilter
+TrigReport        120        536        536          0          0 tprHelixDeIpaTriggerInfoMerger
 
 TrigReport ---------- Modules in path: tprHelixDe_ipa_phiScaled ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -687,11 +702,11 @@ TrigReport        121      20000      20000          0          0 TTmakeSH
 TrigReport        121      20000      20000          0          0 TTmakePH
 TrigReport        121      20000      20000          0          0 TTflagPH
 TrigReport        121      20000      20000          0          0 TTtimeClusterFinder
-TrigReport        121      20000      19893        107          0 tprHelixDeIpaPhiScaledTCFilter
-TrigReport        121      19893      19893          0          0 TThelixFinder
-TrigReport        121      19893      19893          0          0 TTHelixMergerDe
-TrigReport        121      19893        147      19746          0 tprHelixDeIpaPhiScaledHSFilter
-TrigReport        121        147        147          0          0 tprHelixDeIpaPhiScaledTriggerInfoMerger
+TrigReport        121      20000      19889        111          0 tprHelixDeIpaPhiScaledTCFilter
+TrigReport        121      19889      19889          0          0 TThelixFinder
+TrigReport        121      19889      19889          0          0 TTHelixMergerDe
+TrigReport        121      19889        131      19758          0 tprHelixDeIpaPhiScaledHSFilter
+TrigReport        121        131        131          0          0 tprHelixDeIpaPhiScaledTriggerInfoMerger
 
 TrigReport ---------- Modules in path: tprHelixUe ------------
 TrigReport    Path ID    Visited     Passed     Failed      Error Name
@@ -704,82 +719,82 @@ TrigReport        131      20000      20000          0          0 TTmakeSH
 TrigReport        131      20000      20000          0          0 TTmakePH
 TrigReport        131      20000      20000          0          0 TTflagPH
 TrigReport        131      20000      20000          0          0 TTtimeClusterFinderUe
-TrigReport        131      20000      19888        112          0 tprHelixUeTCFilter
-TrigReport        131      19888      19888          0          0 TThelixFinderUe
-TrigReport        131      19888      19888          0          0 TTHelixMergerUe
-TrigReport        131      19888       1940      17948          0 tprHelixUeHSFilter
-TrigReport        131       1940       1940          0          0 tprHelixUeTriggerInfoMerger
+TrigReport        131      20000      19881        119          0 tprHelixUeTCFilter
+TrigReport        131      19881      19881          0          0 TThelixFinderUe
+TrigReport        131      19881      19881          0          0 TTHelixMergerUe
+TrigReport        131      19881       1831      18050          0 tprHelixUeHSFilter
+TrigReport        131       1831       1831          0          0 tprHelixUeTriggerInfoMerger
 
 TrigReport ---------- Module summary ------------
 TrigReport    Visited        Run     Passed     Failed      Error Name
-TrigReport     480000      20000      20000          0          0 CaloClusterFast
-TrigReport     480000      20000      20000          0          0 CaloHitMakerFast
+TrigReport     500000      20000      20000          0          0 CaloClusterFast
+TrigReport     500000      20000      20000          0          0 CaloHitMakerFast
 TrigReport          0          0          0          0          0 CstLineFinder
 TrigReport          0          0          0          0          0 CstSimpleTimeCluster
-TrigReport     114744      16392      16392          0          0 TTAprHelixFinder
-TrigReport     114744      16392      16392          0          0 TTAprHelixMerger
-TrigReport       1028        728        728          0          0 TTAprKSF
-TrigReport        321        321        321          0          0 TTAprUeKSF
-TrigReport       7176       1794       1794          0          0 TTCalHelixFinderDe
-TrigReport       1738       1738       1738          0          0 TTCalHelixFinderUe
-TrigReport       7176       1794       1794          0          0 TTCalHelixMergerDe
-TrigReport       1738       1738       1738          0          0 TTCalHelixMergerUe
-TrigReport        144         83         83          0          0 TTCalSeedFitDe
+TrigReport     114093      16299      16299          0          0 TTAprHelixFinder
+TrigReport     114093      16299      16299          0          0 TTAprHelixMerger
+TrigReport       1015        726        726          0          0 TTAprKSF
+TrigReport        314        314        314          0          0 TTAprUeKSF
+TrigReport       7152       1788       1788          0          0 TTCalHelixFinderDe
+TrigReport       1715       1715       1715          0          0 TTCalHelixFinderUe
+TrigReport       7152       1788       1788          0          0 TTCalHelixMergerDe
+TrigReport       1715       1715       1715          0          0 TTCalHelixMergerUe
+TrigReport        141         82         82          0          0 TTCalSeedFitDe
 TrigReport      80000      20000      20000          0          0 TTCalTimePeakFinder
 TrigReport      20000      20000      20000          0          0 TTCalTimePeakFinderUe
-TrigReport     119402      19937      19937          0          0 TTHelixMergerDe
-TrigReport      19888      19888      19888          0          0 TTHelixMergerUe
-TrigReport       3611       1895       1895          0          0 TTKSFDe
-TrigReport      19893      19893      19893          0          0 TTMprHelixMergerDe
-TrigReport      12558      12558      12558          0          0 TTMprKSFDe
+TrigReport     119380      19935      19935          0          0 TTHelixMergerDe
+TrigReport      19881      19881      19881          0          0 TTHelixMergerUe
+TrigReport       3478       1819       1819          0          0 TTKSFDe
+TrigReport      19889      19889      19889          0          0 TTMprHelixMergerDe
+TrigReport      12429      12429      12429          0          0 TTMprKSFDe
 TrigReport          0          0          0          0          0 TTOmakePH
 TrigReport          0          0          0          0          0 TTOmakeSH
-TrigReport      19893      19893      19893          0          0 TTRobustMultiHelixFinder
-TrigReport     140000      20000      20000          0          0 TTTZClusterFinder
-TrigReport     400000      20000      20000          0          0 TTflagPH
-TrigReport     119402      19937      19937          0          0 TThelixFinder
-TrigReport      19888      19888      19888          0          0 TThelixFinderUe
-TrigReport     400000      20000      20000          0          0 TTmakePH
-TrigReport     400000      20000      20000          0          0 TTmakeSD
-TrigReport     400000      20000      20000          0          0 TTmakeSH
+TrigReport      19889      19889      19889          0          0 TTRobustMultiHelixFinder
+TrigReport     160000      20000      20000          0          0 TTTZClusterFinder
+TrigReport     420000      20000      20000          0          0 TTflagPH
+TrigReport     119380      19935      19935          0          0 TThelixFinder
+TrigReport      19881      19881      19881          0          0 TThelixFinderUe
+TrigReport     420000      20000      20000          0          0 TTmakePH
+TrigReport     420000      20000      20000          0          0 TTmakeSD
+TrigReport     420000      20000      20000          0          0 TTmakeSH
 TrigReport     140000      20000      20000          0          0 TTtimeClusterFinder
 TrigReport      20000      20000      20000          0          0 TTtimeClusterFinderUe
-TrigReport      16392      16392       1305      15087          0 aprHelixHSFilter
-TrigReport      20000      20000      16392       3608          0 aprHelixTCFilter
-TrigReport       1305       1305       1305          0          0 aprHelixTriggerInfoMerger
-TrigReport      16392      16392        321      16071          0 aprHighPHSFilter
-TrigReport        321        321          2        319          0 aprHighPKSFilter
+TrigReport      16299      16299       1259      15040          0 aprHelixHSFilter
+TrigReport      20000      20000      16299       3701          0 aprHelixTCFilter
+TrigReport       1259       1259       1259          0          0 aprHelixTriggerInfoMerger
+TrigReport      16299      16299        314      15985          0 aprHighPHSFilter
+TrigReport        314        314          2        312          0 aprHighPKSFilter
 TrigReport      20000      20000      20000          0          0 aprHighPPS
-TrigReport      16392      16392         79      16313          0 aprHighPStopTargHSFilter
-TrigReport         79         79          1         78          0 aprHighPStopTargKSFilter
-TrigReport      16392      16392          6      16386          0 aprHighPStopTargMultiTrkHSFilter
-TrigReport          6          6          0          6          0 aprHighPStopTargMultiTrkKSFilter
+TrigReport      16299      16299         73      16226          0 aprHighPStopTargHSFilter
+TrigReport         73         73          1         72          0 aprHighPStopTargKSFilter
+TrigReport      16299      16299          7      16292          0 aprHighPStopTargMultiTrkHSFilter
+TrigReport          7          7          0          7          0 aprHighPStopTargMultiTrkKSFilter
 TrigReport      20000      20000      20000          0          0 aprHighPStopTargMultiTrkPS
-TrigReport      20000      20000      16392       3608          0 aprHighPStopTargMultiTrkTCFilter
+TrigReport      20000      20000      16299       3701          0 aprHighPStopTargMultiTrkTCFilter
 TrigReport          0          0          0          0          0 aprHighPStopTargMultiTrkTriggerInfoMerger
 TrigReport      20000      20000      20000          0          0 aprHighPStopTargPS
-TrigReport      20000      20000      16392       3608          0 aprHighPStopTargTCFilter
+TrigReport      20000      20000      16299       3701          0 aprHighPStopTargTCFilter
 TrigReport          1          1          1          0          0 aprHighPStopTargTriggerInfoMerger
-TrigReport      20000      20000      16392       3608          0 aprHighPTCFilter
+TrigReport      20000      20000      16299       3701          0 aprHighPTCFilter
 TrigReport          2          2          2          0          0 aprHighPTriggerInfoMerger
-TrigReport      16392      16392         29      16363          0 aprLowPMultiHelixHSFilter
-TrigReport         29         29          3         26          0 aprLowPMultiHelixKSFilter
+TrigReport      16299      16299         29      16270          0 aprLowPMultiHelixHSFilter
+TrigReport         29         29          2         27          0 aprLowPMultiHelixKSFilter
 TrigReport      20000      20000      20000          0          0 aprLowPMultiHelixPS
-TrigReport      20000      20000      16392       3608          0 aprLowPMultiHelixTCFilter
-TrigReport          3          3          3          0          0 aprLowPMultiHelixTriggerInfoMerger
-TrigReport      16392      16392        593      15799          0 aprLowPStopTargHSFilter
-TrigReport        593        593        133        460          0 aprLowPStopTargKSFilter
+TrigReport      20000      20000      16299       3701          0 aprLowPMultiHelixTCFilter
+TrigReport          2          2          2          0          0 aprLowPMultiHelixTriggerInfoMerger
+TrigReport      16299      16299        592      15707          0 aprLowPStopTargHSFilter
+TrigReport        592        592        124        468          0 aprLowPStopTargKSFilter
 TrigReport      40000      20000      20000          0          0 aprLowPStopTargPS
-TrigReport      20000      20000      16392       3608          0 aprLowPStopTargTCFilter
-TrigReport        133        133        133          0          0 aprLowPStopTargTriggerInfoMerger
-TrigReport      16392      16392        321      16071          0 aprUeHighPHSFilter
-TrigReport        321        321          0        321          0 aprUeHighPKSFilter
+TrigReport      20000      20000      16299       3701          0 aprLowPStopTargTCFilter
+TrigReport        124        124        124          0          0 aprLowPStopTargTriggerInfoMerger
+TrigReport      16299      16299        314      15985          0 aprUeHighPHSFilter
+TrigReport        314        314          0        314          0 aprUeHighPKSFilter
 TrigReport      20000      20000      20000          0          0 aprUeHighPPS
-TrigReport      20000      20000      16392       3608          0 aprUeHighPTCFilter
+TrigReport      20000      20000      16299       3701          0 aprUeHighPTCFilter
 TrigReport          0          0          0          0          0 aprUeHighPTriggerInfoMerger
 TrigReport      20000      20000          0      20000          0 caloFastCosmicFilter
 TrigReport      20000      20000      20000          0          0 caloFastCosmicPS
-TrigReport      20000      20000       1844      18156          0 caloFastMVANNCEFilter
+TrigReport      20000      20000       1858      18142          0 caloFastMVANNCEFilter
 TrigReport      20000      20000      20000          0          0 caloFastMVANNCEPS
 TrigReport      20000      20000        471      19529          0 caloFastPhotonFilter
 TrigReport      20000      20000      20000          0          0 caloFastPhotonPS
@@ -787,28 +802,28 @@ TrigReport      20000      20000          0      20000          0 caloFastRMCFil
 TrigReport      20000      20000      20000          0          0 caloFastRMCPS
 TrigReport          0          0          0          0          0 caloHitRecN0SourceFilter
 TrigReport      20000      20000          0      20000          0 caloHitRecN0SourcePS
-TrigReport       1794       1794         46       1748          0 cprDeHighPHSFilter
-TrigReport         46         46          1         45          0 cprDeHighPKSFilter
+TrigReport       1788       1788         45       1743          0 cprDeHighPHSFilter
+TrigReport         45         45          1         44          0 cprDeHighPKSFilter
 TrigReport      20000      20000      20000          0          0 cprDeHighPPS
-TrigReport       1794       1794         20       1774          0 cprDeHighPStopTargHSFilter
-TrigReport         20         20          1         19          0 cprDeHighPStopTargKSFilter
+TrigReport       1788       1788         19       1769          0 cprDeHighPStopTargHSFilter
+TrigReport         19         19          1         18          0 cprDeHighPStopTargKSFilter
 TrigReport      20000      20000      20000          0          0 cprDeHighPStopTargPS
-TrigReport      20000      20000       1794      18206          0 cprDeHighPStopTargTCFilter
+TrigReport      20000      20000       1788      18212          0 cprDeHighPStopTargTCFilter
 TrigReport          1          1          1          0          0 cprDeHighPStopTargTriggerInfoMerger
-TrigReport      20000      20000       1794      18206          0 cprDeHighPTCFilter
+TrigReport      20000      20000       1788      18212          0 cprDeHighPTCFilter
 TrigReport          1          1          1          0          0 cprDeHighPTriggerInfoMerger
-TrigReport       1794       1794         78       1716          0 cprDeLowPStopTargHSFilter
-TrigReport         78         78         20         58          0 cprDeLowPStopTargKSFilter
+TrigReport       1788       1788         77       1711          0 cprDeLowPStopTargHSFilter
+TrigReport         77         77         19         58          0 cprDeLowPStopTargKSFilter
 TrigReport      20000      20000      20000          0          0 cprDeLowPStopTargPS
-TrigReport      20000      20000       1794      18206          0 cprDeLowPStopTargTCFilter
-TrigReport         20         20         20          0          0 cprDeLowPStopTargTriggerInfoMerger
-TrigReport       1794       1794         82       1712          0 cprHelixDeHSFilter
+TrigReport      20000      20000       1788      18212          0 cprDeLowPStopTargTCFilter
+TrigReport         19         19         19          0          0 cprDeLowPStopTargTriggerInfoMerger
+TrigReport       1788       1788         81       1707          0 cprHelixDeHSFilter
 TrigReport      20000      20000      20000          0          0 cprHelixDePS
-TrigReport      20000      20000       1794      18206          0 cprHelixDeTCFilter
-TrigReport         82         82         82          0          0 cprHelixDeTriggerInfoMerger
-TrigReport       1738       1738         34       1704          0 cprHelixUeHSFilter
+TrigReport      20000      20000       1788      18212          0 cprHelixDeTCFilter
+TrigReport         81         81         81          0          0 cprHelixDeTriggerInfoMerger
+TrigReport       1715       1715         35       1680          0 cprHelixUeHSFilter
 TrigReport      20000      20000      20000          0          0 cprHelixUePS
-TrigReport      20000      20000       1738      18262          0 cprHelixUeTCFilter
+TrigReport      20000      20000       1715      18285          0 cprHelixUeTCFilter
 TrigReport          0          0          0          0          0 cstCosmicTrackSeedCTSFilter
 TrigReport      20000      20000          0      20000          0 cstCosmicTrackSeedPS
 TrigReport          0          0          0          0          0 cstCosmicTrackSeedSDCountFilter
@@ -818,52 +833,54 @@ TrigReport      20000      20000          0      20000          0 cstTimeCluster
 TrigReport          0          0          0          0          0 cstTimeClusterSDCountFilter
 TrigReport          0          0          0          0          0 cstTimeClusterTCFilter
 TrigReport          0          0          0          0          0 cstTimeClusterTriggerInfoMerger
+TrigReport      20000      20000          6      19994          0 lumiBuffer
+TrigReport      20000      20000      20000          0          0 lumiStreamPS
 TrigReport          0          0          0          0          0 minBiasCDCountFilter
 TrigReport      20000      20000          0      20000          0 minBiasCDCountPS
 TrigReport          0          0          0          0          0 minBiasSDCountFilter
 TrigReport      20000      20000          0      20000          0 minBiasSDCountPS
-TrigReport      19893      19893      12558       7335          0 mprDeHighPStopTargHSFilter
-TrigReport      12558      12558        318      12240          0 mprDeHighPStopTargKSFilter
+TrigReport      19889      19889      12429       7460          0 mprDeHighPStopTargHSFilter
+TrigReport      12429      12429        324      12105          0 mprDeHighPStopTargKSFilter
 TrigReport      20000      20000      20000          0          0 mprDeHighPStopTargPS
-TrigReport      20000      20000      19893        107          0 mprDeHighPStopTargTCFilter
-TrigReport        318        318        318          0          0 mprDeHighPStopTargTriggerInfoMerger
-TrigReport     580000      20000      20000          0          0 processCFOData
-TrigReport      19893      19893       1125      18768          0 tprDeHighPHSFilter
-TrigReport       1125       1125          5       1120          0 tprDeHighPKSFilter
+TrigReport      20000      20000      19889        111          0 mprDeHighPStopTargTCFilter
+TrigReport        324        324        324          0          0 mprDeHighPStopTargTriggerInfoMerger
+TrigReport     600000      20000      20000          0          0 processCFOData
+TrigReport      19889      19889       1096      18793          0 tprDeHighPHSFilter
+TrigReport       1096       1096          4       1092          0 tprDeHighPKSFilter
 TrigReport      20000      20000      20000          0          0 tprDeHighPPS
-TrigReport      19893      19893        712      19181          0 tprDeHighPStopTargHSFilter
-TrigReport        712        712          1        711          0 tprDeHighPStopTargKSFilter
+TrigReport      19889      19889        684      19205          0 tprDeHighPStopTargHSFilter
+TrigReport        684        684          0        684          0 tprDeHighPStopTargKSFilter
 TrigReport      20000      20000      20000          0          0 tprDeHighPStopTargPS
-TrigReport      20000      20000      19893        107          0 tprDeHighPStopTargTCFilter
-TrigReport          1          1          1          0          0 tprDeHighPStopTargTriggerInfoMerger
-TrigReport      20000      20000      19893        107          0 tprDeHighPTCFilter
-TrigReport          5          5          5          0          0 tprDeHighPTriggerInfoMerger
-TrigReport      19937      19937       1774      18163          0 tprDeLowPStopTargHSFilter
-TrigReport       1774       1774        141       1633          0 tprDeLowPStopTargKSFilter
+TrigReport      20000      20000      19889        111          0 tprDeHighPStopTargTCFilter
+TrigReport          0          0          0          0          0 tprDeHighPStopTargTriggerInfoMerger
+TrigReport      20000      20000      19889        111          0 tprDeHighPTCFilter
+TrigReport          4          4          4          0          0 tprDeHighPTriggerInfoMerger
+TrigReport      19935      19935       1698      18237          0 tprDeLowPStopTargHSFilter
+TrigReport       1698       1698        146       1552          0 tprDeLowPStopTargKSFilter
 TrigReport      20000      20000      20000          0          0 tprDeLowPStopTargPS
-TrigReport      20000      20000      19937         63          0 tprDeLowPStopTargTCFilter
-TrigReport        141        141        141          0          0 tprDeLowPStopTargTriggerInfoMerger
-TrigReport      19893      19893       1446      18447          0 tprHelixDeHSFilter
-TrigReport      19893      19893        552      19341          0 tprHelixDeIpaHSFilter
+TrigReport      20000      20000      19935         65          0 tprDeLowPStopTargTCFilter
+TrigReport        146        146        146          0          0 tprDeLowPStopTargTriggerInfoMerger
+TrigReport      19889      19889       1391      18498          0 tprHelixDeHSFilter
+TrigReport      19889      19889        536      19353          0 tprHelixDeIpaHSFilter
 TrigReport      20000      20000      20000          0          0 tprHelixDeIpaPS
-TrigReport      19893      19893        147      19746          0 tprHelixDeIpaPhiScaledHSFilter
+TrigReport      19889      19889        131      19758          0 tprHelixDeIpaPhiScaledHSFilter
 TrigReport      20000      20000      20000          0          0 tprHelixDeIpaPhiScaledPS
-TrigReport      20000      20000      19893        107          0 tprHelixDeIpaPhiScaledTCFilter
-TrigReport        147        147        147          0          0 tprHelixDeIpaPhiScaledTriggerInfoMerger
-TrigReport      20000      20000      19893        107          0 tprHelixDeIpaTCFilter
-TrigReport        552        552        552          0          0 tprHelixDeIpaTriggerInfoMerger
+TrigReport      20000      20000      19889        111          0 tprHelixDeIpaPhiScaledTCFilter
+TrigReport        131        131        131          0          0 tprHelixDeIpaPhiScaledTriggerInfoMerger
+TrigReport      20000      20000      19889        111          0 tprHelixDeIpaTCFilter
+TrigReport        536        536        536          0          0 tprHelixDeIpaTriggerInfoMerger
 TrigReport      20000      20000      20000          0          0 tprHelixDePS
-TrigReport      20000      20000      19893        107          0 tprHelixDeTCFilter
-TrigReport       1446       1446       1446          0          0 tprHelixDeTriggerInfoMerger
-TrigReport      19888      19888       1940      17948          0 tprHelixUeHSFilter
+TrigReport      20000      20000      19889        111          0 tprHelixDeTCFilter
+TrigReport       1391       1391       1391          0          0 tprHelixDeTriggerInfoMerger
+TrigReport      19881      19881       1831      18050          0 tprHelixUeHSFilter
 TrigReport      20000      20000      20000          0          0 tprHelixUePS
-TrigReport      20000      20000      19888        112          0 tprHelixUeTCFilter
-TrigReport       1940       1940       1940          0          0 tprHelixUeTriggerInfoMerger
+TrigReport      20000      20000      19881        119          0 tprHelixUeTCFilter
+TrigReport       1831       1831       1831          0          0 tprHelixUeTriggerInfoMerger
 
 TimeReport ---------- Time summary [sec] -------
-TimeReport CPU = 397.265964 Real = 399.547996
+TimeReport CPU = 430.485196 Real = 471.479470
 
 MemReport  ---------- Memory summary [base-10 MB] ------
-MemReport  VmPeak = 9633.72 VmHWM = 615.231
+MemReport  VmPeak = 1592.32 VmHWM = 610.943
 
 Art has completed and will exit with status 0.

--- a/core/producers/trigTrkProducers.fcl
+++ b/core/producers/trigTrkProducers.fcl
@@ -44,13 +44,13 @@ TrigTrkProducers : {
 
    TTmakePH: {
       @table::TrkHitReco.producers.makePH
-      TestFlag   : false # not needed, since TTmakeSH is filtering
+      TestFlag   : true # required as makeSH no longer filters hits
       FilterHits : false
       MinimumTimeOffSpill : 0
       MinimumTimeOffSpill : 100000
       ComboHitCollection    : "TTmakeSH"
-      StrawHitSelectionBits : []
-      StrawHitMask          : []
+      StrawHitSelectionBits : ["TimeSelection"]
+      StrawHitMask          : ["Dead"]
    }
 
    # combine panel hits in a station


### PR DESCRIPTION
Add hit flag checking in panel hit module due to the removal of hit filtering upstream. Also update how the CI test threshold for a major failure is defined